### PR TITLE
Add Next Units publishing calendar

### DIFF
--- a/_toctree.yml
+++ b/_toctree.yml
@@ -6,3 +6,7 @@
     title: Onboarding
   - local: unit0/03_discord101
     title: (Optional) Discord 101
+- title: When the next steps are published?
+  sections:
+  - local: communication/next-units
+    title: Next Units

--- a/units/communication/next-units.mdx
+++ b/units/communication/next-units.mdx
@@ -1,0 +1,9 @@
+# When the next units get published?
+
+Here's the publication schedule:
+
+<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/communication/next-units.jpg" alt="Next Units" width="100%"/>
+
+Don't forget to <a href="https://bit.ly/hf-learn-agents">sign up for the course</a>! By signing up, **we can send you the links as each unit is published, along with updates and details about upcoming challenges**.
+
+Keep Learning, Stay Awesome 🤗


### PR DESCRIPTION
Context: After the last unit of the course, we have this section that gives them information about the next units + CTA sign up for the course.