### PR TITLE
fix(doc): change relative paths of units 2-4 readme in the repo README.md to proper ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ You can access the course here 👉 https://hf.co/learn/agents-course
 |------|--------------------------------|-----------------------------------------------------------------------------|
 | 0    | [Welcome to the Course](https://huggingface.co/learn/agents-course/en/unit0/introduction) | Welcome, guidelines, necessary tools, and course overview.                  |
 | 1    | [Introduction to Agents](https://huggingface.co/learn/agents-course/en/unit1/introduction)       | Definition of agents, LLMs, model family tree, and special tokens.          |
-| 2    | [2_frameworks](units/unit2/README.md)                     | Overview of smolagents, LangChain, LangGraph, and LlamaIndex.               |
-| 3    | [3_use_cases](units/unit3/README.md)                      | SQL, code, retrieval, and on-device agents using various frameworks.        |
-| 4    | [4_final_assignment_with_benchmark](units/unit4/README.md) | Automated evaluation of agents and leaderboard with student results.        |
+| 2    | [2_frameworks](units/en/unit2/README.md)                     | Overview of smolagents, LangChain, LangGraph, and LlamaIndex.               |
+| 3    | [3_use_cases](units/en/unit3/README.md)                      | SQL, code, retrieval, and on-device agents using various frameworks.        |
+| 4    | [4_final_assignment_with_benchmark](units/en/unit4/README.md) | Automated evaluation of agents and leaderboard with student results.        |
 
 
 ## Prerequisites


### PR DESCRIPTION
Even though it is expected (I assume) to be changed later to a proper path on HF website, to avoid confusion I guess it's better to redirect to the en readme (even empty) instead of the 404 currently shown