### PR TITLE
`Unit 1` suggestions for improvement

### DIFF
--- a/units/en/unit1/what-are-llms.mdx
+++ b/units/en/unit1/what-are-llms.mdx
@@ -69,7 +69,7 @@ You can experiment with different tokenizers in the interactive playground below
 	height="450"
 ></iframe>
 
-Each LLM has some **special tokens** specific to the model. The LLM uses these tokens to open and close the structured components of its generation. For example, to start a sequence, message, or response, and to close sequences or messages. Moreover, the input prompts that we pass to the model are also structured with special tokens. The most important of those is the **End of sequence token** (EOS).
+Each LLM has some **special tokens** specific to the model. The LLM uses these tokens to open and close the structured components of its generation. For example, to indicate the start or end of a sequence, message, or response. Moreover, the input prompts that we pass to the model are also structured with special tokens. The most important of those is the **End of sequence token** (EOS).
 
 The forms of special tokens are highly diverse across model providers.
 

--- a/units/en/unit1/what-are-llms.mdx
+++ b/units/en/unit1/what-are-llms.mdx
@@ -92,7 +92,7 @@ The forms of special tokens are highly diverse across model providers.
       <td>End of message text</td>
     </tr>
     <tr>
-      <td><strong>LLaMA3</strong></td>
+      <td><strong>Llama 3</strong></td>
       <td>Meta (Facebook AI Research)</td>
       <td><code>&lt;|eot_id|&gt;</code></td>
       <td>End of sequence</td>

--- a/units/en/unit1/what-are-llms.mdx
+++ b/units/en/unit1/what-are-llms.mdx
@@ -119,7 +119,7 @@ The forms of special tokens are highly diverse across model providers.
 </table>
 
 <Tip>
-We do not expect you to memorize these special tokens, but it is important to appreciate their diversity and the role they play in the text generation of LLMs. If you want to know more about special tokens, you can check out the configuration of the model in its Hub repository. For example, you can find the special tokens of the SmollLM2 model in its [tokenizer_config.json](https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct/blob/main/tokenizer_config.json).
+We do not expect you to memorize these special tokens, but it is important to appreciate their diversity and the role they play in the text generation of LLMs. If you want to know more about special tokens, you can check out the configuration of the model in its Hub repository. For example, you can find the special tokens of the SmollLM2 model in its <a href="https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct/blob/main/tokenizer_config.json">tokenizer_config.json</a>.
 </Tip>
 
 ## Understanding next token prediction.


### PR DESCRIPTION
Suggestions:

* Simplified sentence `For example, to start a sequence, message, or response, and to close sequences or messages.` -> `For example, to indicate the start or end of a sequence, message, or response.`
* LLaMA3 -> Llama 3 to keep naming consistency
* URL not rendered so using HTML instead 👇

![image](https://github.com/user-attachments/assets/ecb07ef1-7b2c-4a84-a595-78122dcbd545)
