### PR TITLE
correct model name typo

### DIFF
--- a/units/en/unit1/what-are-llms.mdx
+++ b/units/en/unit1/what-are-llms.mdx
@@ -50,7 +50,7 @@ Although Large Language Models come in various forms, LLMs are typically decoder
 | **Deepseek-R1**                    | DeepSeek                                  |
 | **GPT4**                           | OpenAI                                    |
 | **Llama 3**                        | Meta (Facebook AI Research)               |
-| **SmollLM2**                       | Hugging Face     |
+| **SmolLM2**                       | Hugging Face     |
 | **Gemma**                          | Google                                    |
 | **Mistral**                        | Mistral                                |
 
@@ -104,7 +104,7 @@ The forms of special tokens are highly diverse across model providers.
       <td>End of message text</td>
     </tr>
     <tr>
-      <td><strong>SmollLM2</strong></td>
+      <td><strong>SmolLM2</strong></td>
       <td>Hugging Face</td>
       <td><code>&lt;|im_end|&gt;</code></td>
       <td>End of instruction or message</td>
@@ -119,7 +119,7 @@ The forms of special tokens are highly diverse across model providers.
 </table>
 
 <Tip>
-We do not expect you to memorize these special tokens, but it is important to appreciate their diversity and the role they play in the text generation of LLMs. If you want to know more about special tokens, you can check out the configuration of the model in its Hub repository. For example, you can find the special tokens of the SmollLM2 model in its <a href="https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct/blob/main/tokenizer_config.json">tokenizer_config.json</a>.
+We do not expect you to memorize these special tokens, but it is important to appreciate their diversity and the role they play in the text generation of LLMs. If you want to know more about special tokens, you can check out the configuration of the model in its Hub repository. For example, you can find the special tokens of the SmolLM2 model in its <a href="https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct/blob/main/tokenizer_config.json">tokenizer_config.json</a>.
 </Tip>
 
 ## Understanding next token prediction.
@@ -141,7 +141,7 @@ Based on these scores, we have multiple strategies to select the tokens to compl
 
 - The easiest decoding strategy would be to always take the token with the maximum score.
 
-You can interact with the decoding process yourself with SmollLM2 in this Space (remember, it decodes until reaching an **EOS** token which is  **<|im_end|>** for this model):
+You can interact with the decoding process yourself with SmolLM2 in this Space (remember, it decodes until reaching an **EOS** token which is  **<|im_end|>** for this model):
 
 <iframe
 	src="https://agents-course-decoding-visualizer.hf.space"


### PR DESCRIPTION
This fixes a typo in the SmolLM2 model name in the file what-are-llms.mdx.