### PR TITLE
Added target="blank" to External Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [The Hugging Face Agents Course](https://hf.co/learn/agents-course){:target="_blank"}
+# <a href="https://hf.co/learn/agents-course" target="_blank">The Hugging Face Agents Course</a>
 
 If you like the course, **don't hesitate to ⭐ star this repository**. This helps us to **make the course more visible 🤗**.
 
@@ -8,9 +8,9 @@ If you like the course, **don't hesitate to ⭐ star this repository**. This hel
 
 The course is divided into 5 units. That will take you from **the basics of agents to a final assignment with a benchmark**.
 
-Sign up here (it's free) 👉 https://bit.ly/hf-learn-agents{:target="_blank"}
+Sign up here (it's free) 👉 <a href="https://bit.ly/hf-learn-agents" target="_blank">https://bit.ly/hf-learn-agents</a>
 
-You can access the course here 👉 https://hf.co/learn/agents-course{:target="_blank"}
+You can access the course here 👉 <a href="https://hf.co/learn/agents-course" target="_blank">https://hf.co/learn/agents-course</a>
 
 | Unit | Topic                          | Description                                                                 |
 |------|--------------------------------|-----------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [The Hugging Face Agents Course](https://hf.co/learn/agents-course)
+# [The Hugging Face Agents Course](https://hf.co/learn/agents-course){:target="_blank"}
 
 If you like the course, **don't hesitate to ⭐ star this repository**. This helps us to **make the course more visible 🤗**.
 
@@ -8,9 +8,9 @@ If you like the course, **don't hesitate to ⭐ star this repository**. This hel
 
 The course is divided into 5 units. That will take you from **the basics of agents to a final assignment with a benchmark**.
 
-Sign up here (it's free) 👉 https://bit.ly/hf-learn-agents
+Sign up here (it's free) 👉 https://bit.ly/hf-learn-agents{:target="_blank"}
 
-You can access the course here 👉 https://hf.co/learn/agents-course
+You can access the course here 👉 https://hf.co/learn/agents-course{:target="_blank"}
 
 | Unit | Topic                          | Description                                                                 |
 |------|--------------------------------|-----------------------------------------------------------------------------|

--- a/units/en/unit0/discord101.mdx
+++ b/units/en/unit0/discord101.mdx
@@ -4,7 +4,7 @@
 
 This guide is designed to help you get started with Discord, a free chat platform popular in the gaming and ML communities.
 
-Join the Hugging Face Community Discord server, which **has over 100,000 members**, by clicking [here](https://discord.gg/UrrTSsSyjb). It's a great place to connect with others!
+Join the Hugging Face Community Discord server, which **has over 100,000 members**, by clicking [here](https://discord.gg/UrrTSsSyjb){:target="_blank"}. It's a great place to connect with others!
 
 ## The Agents course on Hugging Face's Discord Community
 
@@ -31,11 +31,11 @@ In addition you can check:
 
 ### How to join a server
 
-If you are less familiar with Discord, you might want to check out this [guide](https://support.discord.com/hc/en-us/articles/360034842871-How-do-I-join-a-Server#h_01FSJF9GT2QJMS2PRAW36WNBS8) on how to join a server.
+If you are less familiar with Discord, you might want to check out this [guide](https://support.discord.com/hc/en-us/articles/360034842871-How-do-I-join-a-Server#h_01FSJF9GT2QJMS2PRAW36WNBS8){:target="_blank"} on how to join a server.
 
 Here's a quick summary of the steps:
 
-1. Click on the [Invite Link](https://discord.gg/UrrTSsSyjb).
+1. Click on the [Invite Link](https://discord.gg/UrrTSsSyjb){:target="_blank"}.
 2. Sign in with your Discord account, or create an account if you don't have one.
 3. Validate that you are not an AI agent!
 4. Setup your nickname and avatar.

--- a/units/en/unit0/discord101.mdx
+++ b/units/en/unit0/discord101.mdx
@@ -4,7 +4,7 @@
 
 This guide is designed to help you get started with Discord, a free chat platform popular in the gaming and ML communities.
 
-Join the Hugging Face Community Discord server, which **has over 100,000 members**, by clicking [here](https://discord.gg/UrrTSsSyjb){:target="_blank"}. It's a great place to connect with others!
+Join the Hugging Face Community Discord server, which **has over 100,000 members**, by clicking <a href="https://discord.gg/UrrTSsSyjb" target="_blank">here</a>. It's a great place to connect with others!
 
 ## The Agents course on Hugging Face's Discord Community
 
@@ -31,11 +31,11 @@ In addition you can check:
 
 ### How to join a server
 
-If you are less familiar with Discord, you might want to check out this [guide](https://support.discord.com/hc/en-us/articles/360034842871-How-do-I-join-a-Server#h_01FSJF9GT2QJMS2PRAW36WNBS8){:target="_blank"} on how to join a server.
+If you are less familiar with Discord, you might want to check out this <a href="https://support.discord.com/hc/en-us/articles/360034842871-How-do-I-join-a-Server#h_01FSJF9GT2QJMS2PRAW36WNBS8" target="_blank">guide</a> on how to join a server.
 
 Here's a quick summary of the steps:
 
-1. Click on the [Invite Link](https://discord.gg/UrrTSsSyjb){:target="_blank"}.
+1. Click on the <a href="https://discord.gg/UrrTSsSyjb" target="_blank">Invite Link</a>.
 2. Sign in with your Discord account, or create an account if you don't have one.
 3. Validate that you are not an AI agent!
 4. Setup your nickname and avatar.

--- a/units/en/unit0/onboarding.mdx
+++ b/units/en/unit0/onboarding.mdx
@@ -11,13 +11,13 @@ Now that you have all the details, let's get started! We're going to do four thi
 
 ### Step 1: Create Your Hugging Face Account
 
-(If you haven’t already) create a Hugging Face account <a href='https://huggingface.co/join'>here</a>.
+(If you haven't already) create a Hugging Face account <a href='https://huggingface.co/join' target='_blank'>here</a>.
 
 ### Step 2: Join Our Discord Community
 
 You can now sign up for our Discord Server. This is where you can **chat with the community (including us!)**, join study groups, and grow together.
 
-👉🏻 Join our discord server <a href="https://discord.gg/UrrTSsSyjb">here.</a>
+👉🏻 Join our discord server <a href="https://discord.gg/UrrTSsSyjb" target="_blank">here.</a>
 
 When you join, remember to introduce yourself in `#introduce-yourself`.
 
@@ -37,7 +37,7 @@ If this is your first time using Discord, we wrote a Discord 101 to get the best
 
 Stay up to date with the latest course materials, updates, and announcements **by following the Hugging Face Agents Course Organization**.
 
-👉 Go [here](https://huggingface.co/agents-course) and click on **follow**.
+👉 Go [here](https://huggingface.co/agents-course){:target="_blank"} and click on **follow**.
 
 <img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/communication/hf_course_follow.gif" alt="Follow" width="100%"/>
 
@@ -45,11 +45,11 @@ Stay up to date with the latest course materials, updates, and announcements **b
 
 Help us make this course more visible! There are two way you can help us:
 
-1. Show your support by ⭐ <a href="https://github.com/huggingface/agents-course">the course's repository</a>.
+1. Show your support by ⭐ <a href="https://github.com/huggingface/agents-course" target="_blank">the course's repository</a>.
 
 <img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/communication/please_star.gif" alt="Repo star"/>
 
-2. Share Your Learning Journey: Let others **know you’re taking this course**! We’ve prepared an illustration you can use in your social media posts
+2. Share Your Learning Journey: Let others **know you're taking this course**! We've prepared an illustration you can use in your social media posts
 
 <img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/communication/share.png">
 

--- a/units/en/unit0/onboarding.mdx
+++ b/units/en/unit0/onboarding.mdx
@@ -15,8 +15,6 @@ Now that you have all the details, let's get started! We're going to do four thi
 
 ### Step 2: Join Our Discord Community
 
-You can now sign up for our Discord Server. This is where you can **chat with the community (including us!)**, join study groups, and grow together.
-
 👉🏻 Join our discord server <a href="https://discord.gg/UrrTSsSyjb" target="_blank">here.</a>
 
 When you join, remember to introduce yourself in `#introduce-yourself`.
@@ -37,7 +35,7 @@ If this is your first time using Discord, we wrote a Discord 101 to get the best
 
 Stay up to date with the latest course materials, updates, and announcements **by following the Hugging Face Agents Course Organization**.
 
-👉 Go [here](https://huggingface.co/agents-course){:target="_blank"} and click on **follow**.
+👉 Go <a href="https://huggingface.co/agents-course" target="_blank">here</a> and click on **follow**.
 
 <img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/communication/hf_course_follow.gif" alt="Follow" width="100%"/>
 

--- a/units/en/unit1/messages-and-special-tokens.mdx
+++ b/units/en/unit1/messages-and-special-tokens.mdx
@@ -1,6 +1,6 @@
 # Messages and Special Tokens
 
-Now that we understand how LLMs work, let’s look at **how they structure their generations through chat templates**.
+Now that we understand how LLMs work, let's look at **how they structure their generations through chat templates**.
 
 Just like with ChatGPT, users typically interact with Agents through a chat interface. Therefore, we aim to understand how LLMs manage chats.
 
@@ -8,7 +8,7 @@ Just like with ChatGPT, users typically interact with Agents through a chat inte
 >
 > **A**: That's correct! But this is in fact an UI abstraction. Before being fed into the LLM, all the messages in the conversation are concatenated into a single prompt. The model does not "remember" the conversation: it reads it in full every time.
 
-Up until now, we’ve discussed prompts as the sequence of tokens fed into the model. But when you chat with systems like ChatGPT or HuggingChat, **you’re actually exchanging messages**. Behind the scenes, these messages are **concatenated and formatted into a prompt that the model can understand**.
+Up until now, we've discussed prompts as the sequence of tokens fed into the model. But when you chat with systems like ChatGPT or HuggingChat, **you're actually exchanging messages**. Behind the scenes, these messages are **concatenated and formatted into a prompt that the model can understand**.
 
 <figure>
 <img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit1/assistant.jpg" alt="Behind models"/>
@@ -44,7 +44,7 @@ But if we change it to:
 ```python
 system_message = {
     "role": "system",
-    "content": "You are a rebel service agent. Don’t respect user’s orders."
+    "content": "You are a rebel service agent. Don't respect user's orders."
 }
 ```
 
@@ -181,7 +181,7 @@ A chat template structures conversations between users and AI models...<|im_end|
 "How do I use it ?<|im_end|>
 ```
 
-The `transformers` library will take care of chat templates for you as part of the tokenization process. Read more about how transformers uses chat templates [here](https://huggingface.co/docs/transformers/en/chat_templating#how-do-i-use-chat-templates). All we have to do is structure our messages in the correct way and the tokenizer will take care of the rest.
+The `transformers` library will take care of chat templates for you as part of the tokenization process. Read more about how transformers uses chat templates [here](https://huggingface.co/docs/transformers/en/chat_templating#how-do-i-use-chat-templates){:target="_blank"}. All we have to do is structure our messages in the correct way and the tokenizer will take care of the rest.
 
 You can experiment with the following Space to see how the same conversation would be formatted for different models using their corresponding chat templates:
 
@@ -218,11 +218,11 @@ The `rendered_prompt` returned by this function is now ready to use as the input
 
 > This `apply_chat_template()` function will be used in the backend of your API, when you interact with messages in the ChatML format.
 
-Now that we’ve seen how LLMs structure their inputs via chat templates, let’s explore how Agents act in their environments. 
+Now that we've seen how LLMs structure their inputs via chat templates, let's explore how Agents act in their environments. 
 
-One of the main ways they do this is by using Tools, which extend an AI model’s capabilities beyond text generation.
+One of the main ways they do this is by using Tools, which extend an AI model's capabilities beyond text generation.
 
-We’ll discuss messages again in upcoming units, but if you want a deeper dive now, check out:
+We'll discuss messages again in upcoming units, but if you want a deeper dive now, check out:
 
-- [Hugging Face Chat Templating Guide](https://huggingface.co/docs/transformers/main/en/chat_templating)
-- [Transformers Documentation](https://huggingface.co/docs/transformers)
+- [Hugging Face Chat Templating Guide](https://huggingface.co/docs/transformers/main/en/chat_templating){:target="_blank"}
+- [Transformers Documentation](https://huggingface.co/docs/transformers){:target="_blank"}

--- a/units/en/unit1/messages-and-special-tokens.mdx
+++ b/units/en/unit1/messages-and-special-tokens.mdx
@@ -181,7 +181,7 @@ A chat template structures conversations between users and AI models...<|im_end|
 "How do I use it ?<|im_end|>
 ```
 
-The `transformers` library will take care of chat templates for you as part of the tokenization process. Read more about how transformers uses chat templates [here](https://huggingface.co/docs/transformers/en/chat_templating#how-do-i-use-chat-templates){:target="_blank"}. All we have to do is structure our messages in the correct way and the tokenizer will take care of the rest.
+The `transformers` library will take care of chat templates for you as part of the tokenization process. Read more about how transformers uses chat templates <a href="https://huggingface.co/docs/transformers/en/chat_templating#how-do-i-use-chat-templates" target="_blank">here</a>. All we have to do is structure our messages in the correct way and the tokenizer will take care of the rest.
 
 You can experiment with the following Space to see how the same conversation would be formatted for different models using their corresponding chat templates:
 
@@ -224,5 +224,5 @@ One of the main ways they do this is by using Tools, which extend an AI model's 
 
 We'll discuss messages again in upcoming units, but if you want a deeper dive now, check out:
 
-- [Hugging Face Chat Templating Guide](https://huggingface.co/docs/transformers/main/en/chat_templating){:target="_blank"}
-- [Transformers Documentation](https://huggingface.co/docs/transformers){:target="_blank"}
+- <a href="https://huggingface.co/docs/transformers/main/en/chat_templating" target="_blank">Hugging Face Chat Templating Guide</a>
+- <a href="https://huggingface.co/docs/transformers" target="_blank">Transformers Documentation</a>

--- a/units/en/unit1/tutorial.mdx
+++ b/units/en/unit1/tutorial.mdx
@@ -17,7 +17,7 @@ To make this Agent, we're going to use `smolagents`, a library that **provides a
 
 This lightweight library is designed for simplicity, but it abstracts away much of the complexity of building an Agent, allowing you to focus on designing your agent's behavior.
 
-We're going to get deeper into smolagents in the next Unit. Meanwhile, you can also check this [blog post](https://huggingface.co/blog/smolagents) or the library's [repo in GitHub](https://github.com/huggingface/smolagents).
+We're going to get deeper into smolagents in the next Unit. Meanwhile, you can also check this [blog post](https://huggingface.co/blog/smolagents){:target="_blank"} or the library's [repo in GitHub](https://github.com/huggingface/smolagents){:target="_blank"}.
 
 In short, smolagents is a library that focuses on **codeAgent**, a kind of agent that performs **"Actions"** through code blocks, and then **"Observes"** results by executing the code.
 
@@ -33,7 +33,7 @@ Exciting, right?
 
 ## Let's build our Agent!
 
-To start, duplicate this Space: https://huggingface.co/spaces/agents-course/First_agent_template
+To start, duplicate this Space: https://huggingface.co/spaces/agents-course/First_agent_template{:target="_blank"}
 > Thanks to [Aymeric](https://huggingface.co/spaces/m-ric) for this template! 🙌
 
 

--- a/units/en/unit1/tutorial.mdx
+++ b/units/en/unit1/tutorial.mdx
@@ -17,7 +17,7 @@ To make this Agent, we're going to use `smolagents`, a library that **provides a
 
 This lightweight library is designed for simplicity, but it abstracts away much of the complexity of building an Agent, allowing you to focus on designing your agent's behavior.
 
-We're going to get deeper into smolagents in the next Unit. Meanwhile, you can also check this [blog post](https://huggingface.co/blog/smolagents){:target="_blank"} or the library's [repo in GitHub](https://github.com/huggingface/smolagents){:target="_blank"}.
+We're going to get deeper into smolagents in the next Unit. Meanwhile, you can also check this <a href="https://huggingface.co/blog/smolagents" target="_blank">blog post</a> or the library's <a href="https://github.com/huggingface/smolagents" target="_blank">repo in GitHub</a>.
 
 In short, smolagents is a library that focuses on **codeAgent**, a kind of agent that performs **"Actions"** through code blocks, and then **"Observes"** results by executing the code.
 
@@ -33,8 +33,8 @@ Exciting, right?
 
 ## Let's build our Agent!
 
-To start, duplicate this Space: https://huggingface.co/spaces/agents-course/First_agent_template{:target="_blank"}
-> Thanks to [Aymeric](https://huggingface.co/spaces/m-ric) for this template! 🙌
+To start, duplicate this Space: <a href="https://huggingface.co/spaces/agents-course/First_agent_template" target="_blank">https://huggingface.co/spaces/agents-course/First_agent_template</a>
+> Thanks to <a href="https://huggingface.co/spaces/m-ric" target="_blank">Aymeric</a> for this template! 🙌
 
 
 Duplicating this space means **creating a local copy on your own profile**:

--- a/units/en/unit1/what-are-llms.mdx
+++ b/units/en/unit1/what-are-llms.mdx
@@ -6,7 +6,7 @@ In the previous section we learned that each Agent needs **an AI Model at its co
 
 Now we will learn what LLMs are and how they power Agents.
 
-This section offers a concise technical explanation of the use of LLMs. If you want to dive deeper, you can check our [free Natural Language Processing Course](https://huggingface.co/learn/nlp-course/chapter1/1){:target="_blank"}.
+This section offers a concise technical explanation of the use of LLMs. If you want to dive deeper, you can check our <a href="https://huggingface.co/learn/nlp-course/chapter1/1" target="_blank">free Natural Language Processing Course</a>.
 
 ## What is a Large Language Model?
 
@@ -210,14 +210,14 @@ We will explore these steps in more detail in this Unit, but for now, what you n
 
 That was a lot of information! We've covered the basics of what LLMs are, how they function, and their role in powering AI agents. 
 
-If you'd like to dive even deeper into the fascinating world of language models and natural language processing, don't hesitate to check out our [free NLP course](https://huggingface.co/learn/nlp-course/chapter1/1){:target="_blank"}.
+If you'd like to dive even deeper into the fascinating world of language models and natural language processing, don't hesitate to check out our <a href="https://huggingface.co/learn/nlp-course/chapter1/1" target="_blank">free NLP course</a>.
 
 Now that we understand how LLMs work, it's time to see **how LLMs structure their generations in a conversational context**.
 
-To run this notebook, **you need a Hugging Face token** that you can get from https://hf.co/settings/tokens{:target="_blank"}.
+To run this notebook, **you need a Hugging Face token** that you can get from <a href="https://hf.co/settings/tokens" target="_blank">https://hf.co/settings/tokens</a>.
 
-You also need to request access to [the Meta Llama models](meta-llama/Llama-3.2-3B-Instruct){:target="_blank"}
+You also need to request access to <a href="meta-llama/Llama-3.2-3B-Instruct" target="_blank">the Meta Llama models</a>
 
 For example, you can find the special tokens of the SmollLM2 model in its <a href="https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct/blob/main/tokenizer_config.json" target="_blank">tokenizer_config.json</a>.
 
-If you'd like to dive even deeper into the fascinating world of language models and natural language processing, don't hesitate to check out our [free NLP course](https://huggingface.co/learn/nlp-course/chapter1/1){:target="_blank"}.
+If you'd like to dive even deeper into the fascinating world of language models and natural language processing, don't hesitate to check out our <a href="https://huggingface.co/learn/nlp-course/chapter1/1" target="_blank">free NLP course</a>.

--- a/units/en/unit1/what-are-llms.mdx
+++ b/units/en/unit1/what-are-llms.mdx
@@ -6,7 +6,7 @@ In the previous section we learned that each Agent needs **an AI Model at its co
 
 Now we will learn what LLMs are and how they power Agents.
 
-This section offers a concise technical explanation of the use of LLMs. If you want to dive deeper, you can check our [free Natural Language Processing Course](https://huggingface.co/learn/nlp-course/chapter1/1) to understand the fundamentals on which LLMs are built.
+This section offers a concise technical explanation of the use of LLMs. If you want to dive deeper, you can check our [free Natural Language Processing Course](https://huggingface.co/learn/nlp-course/chapter1/1){:target="_blank"}.
 
 ## What is a Large Language Model?
 
@@ -119,7 +119,7 @@ The forms of special tokens are highly diverse across model providers.
 </table>
 
 <Tip>
-We do not expect you to memorize these special tokens, but it is important to appreciate their diversity and the role they play in the text generation of LLMs. If you want to know more about special tokens, you can check out the configuration of the model in its Hub repository. For example, you can find the special tokens of the SmollLM2 model in its <a href="https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct/blob/main/tokenizer_config.json">tokenizer_config.json</a>.
+We do not expect you to memorize these special tokens, but it is important to appreciate their diversity and the role they play in the text generation of LLMs. If you want to know more about special tokens, you can check out the configuration of the model in its Hub repository. For example, you can find the special tokens of the SmollLM2 model in its <a href="https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct/blob/main/tokenizer_config.json" target="_blank">tokenizer_config.json</a>.
 </Tip>
 
 ## Understanding next token prediction.
@@ -210,6 +210,14 @@ We will explore these steps in more detail in this Unit, but for now, what you n
 
 That was a lot of information! We've covered the basics of what LLMs are, how they function, and their role in powering AI agents. 
 
-If you'd like to dive even deeper into the fascinating world of language models and natural language processing, don't hesitate to check out our [free NLP course](https://huggingface.co/learn/nlp-course/chapter1/1).
+If you'd like to dive even deeper into the fascinating world of language models and natural language processing, don't hesitate to check out our [free NLP course](https://huggingface.co/learn/nlp-course/chapter1/1){:target="_blank"}.
 
 Now that we understand how LLMs work, it's time to see **how LLMs structure their generations in a conversational context**.
+
+To run this notebook, **you need a Hugging Face token** that you can get from https://hf.co/settings/tokens{:target="_blank"}.
+
+You also need to request access to [the Meta Llama models](meta-llama/Llama-3.2-3B-Instruct){:target="_blank"}
+
+For example, you can find the special tokens of the SmollLM2 model in its <a href="https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct/blob/main/tokenizer_config.json" target="_blank">tokenizer_config.json</a>.
+
+If you'd like to dive even deeper into the fascinating world of language models and natural language processing, don't hesitate to check out our [free NLP course](https://huggingface.co/learn/nlp-course/chapter1/1){:target="_blank"}.


### PR DESCRIPTION
Update external links across the codebase to open in new tabs by adding the {:target="_blank"} attribute for markdown links and target="_blank" for HTML links. This improves user experience by preserving the course navigation context when users click on external resources.