### PR TITLE
Fix python syntax error in tools.mdx.

### DIFF
--- a/units/en/unit1/tools.mdx
+++ b/units/en/unit1/tools.mdx
@@ -202,7 +202,7 @@ calculator_tool = Tool(
     "calculator",                   # name
     "Multiply two integers.",       # description
     calculator,                     # function to call
-    [("a": "int"), ("b": "int")],   # inputs (names and types)
+    [("a", "int"), ("b", "int")],   # inputs (names and types)
     "int",                          # output
 )
 ```


### PR DESCRIPTION
Replaced colons by commas in tuples.