### PR TITLE
add print statement to demonstrate chat completion output

### DIFF
--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -76,6 +76,7 @@ output = client.chat.completions.create(
     stream=False,
     max_tokens=1024,
 )
+print(output.choices[0].message.content)
 ```
 output:
 ```


### PR DESCRIPTION
Add the line `print(output.choices[0].message.content)` to print the actual output shown in the next block.