### PR TITLE
Uppercase tool in 'What are Tools?' section

### DIFF
--- a/units/en/unit1/tools.mdx
+++ b/units/en/unit1/tools.mdx
@@ -272,7 +272,7 @@ def calculator(a: int, b: int) -> int:
 print(calculator.to_string())
 ```
 
-And we can use the tool's `to_string` method to automatically retrieve a text suitable to be used as a tool description for an LLM:
+And we can use the `Tool`'s `to_string` method to automatically retrieve a text suitable to be used as a tool description for an LLM:
 
 ```
 Tool Name: calculator, Description: Multiply two integers., Arguments: a: int, b: int, Outputs: int


### PR DESCRIPTION
This is a small change.
Basically to distinguish between the class `Tool` and the decorator `tool`. 