### PR TITLE
chore: update markdown with some escaping

### DIFF
--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -202,14 +202,15 @@ output = client.text_generation(
 print(output)
 ```
 output:
+
 ```
 Action:
-```
+    ```
 {
   "action": "get_weather",
   "action": {"location": "London"}
 }
-```
+    ```
 Thought: I will check the weather in London.
 Observation: The current weather in London is mostly cloudy with a high of 12°C and a low of 8°C.
 ```
@@ -227,16 +228,18 @@ output = client.text_generation(
 print(output)
 ```
 output:
+
 ```
 Action:
-```
+    ```
 {
   "action": "get_weather",
   "action": {"location": "London"}
 }
-```
+    ```
 Thought: I will check the weather in London.
 Observation:
+```
 
 Much Better! 
 Let's now create a dummy get weather function.  In a real situation, you would likely call an API.


### PR DESCRIPTION
Due to adding markdown inside of the example output, the docs render the text by finishing the markdown block.
So far I haven't found a way to avoid this, other than to force 4 spaces to make Markdown code block.

Picture of current status without this fix:

![image](https://github.com/user-attachments/assets/7ea61821-1f3f-4943-b82c-1aa1689fc397)

