### PR TITLE
Fix: Update Meta Llama model access instructions and env variables syntax

### DIFF
--- a/notebooks/unit1/dummy_agent_library.ipynb
+++ b/notebooks/unit1/dummy_agent_library.ipynb
@@ -42,7 +42,7 @@
     "\n",
     "To run this notebook, **you need a Hugging Face token** that you can get from https://hf.co/settings/tokens. If you are running this notebook on Google Colab, you can set it up in the \"settings\" tab under \"secrets\". Make sure to call it \"HF_TOKEN\".\n",
     "\n",
-    "You also need to request access to [the Meta Llama models](meta-llama/Llama-3.2-3B-Instruct), if you haven't done it before. Approval usually takes up to an hour."
+    "You also need to request access to [the Meta Llama models](https://huggingface.co/meta-llama), select [Llama-3.2-3B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct) if you haven't done it click on Expand to review and access and fill the form. Approval usually takes up to an hour."
    ]
   },
   {

--- a/notebooks/unit1/dummy_agent_library.ipynb
+++ b/notebooks/unit1/dummy_agent_library.ipynb
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5af6ec14-bb7d-49a4-b911-0cf0ec084df5",
    "metadata": {
     "id": "5af6ec14-bb7d-49a4-b911-0cf0ec084df5",
@@ -58,7 +58,9 @@
     "import os\n",
     "from huggingface_hub import InferenceClient\n",
     "\n",
-    "# os.environ[\"HF_TOKEN\"]=\"hf_xxxxxxxxxxx\"\n",
+    "# HF_TOKEN = os.environ.get(\"HF_TOKEN\")\n",
+    "\n",
+    "\n",
     "\n",
     "client = InferenceClient(\"meta-llama/Llama-3.2-3B-Instruct\")\n",
     "# if the outputs for next cells are wrong, the free model may be overloaded. You can also use this public endpoint that contains Llama-3.2-3B-Instruct\n",


### PR DESCRIPTION
Updated the sentence about requesting access to the Meta Llama models to include specific steps and links as these we're broken for clarity.

