### PR TITLE
Removing repeated reference to NLP course

### DIFF
--- a/units/en/unit1/what-are-llms.mdx
+++ b/units/en/unit1/what-are-llms.mdx
@@ -221,5 +221,3 @@ To run this notebook, **you need a Hugging Face token** that you can get from <a
 You also need to request access to <a href="meta-llama/Llama-3.2-3B-Instruct" target="_blank">the Meta Llama models</a>
 
 For example, you can find the special tokens of the SmollLM2 model in its <a href="https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct/blob/main/tokenizer_config.json" target="_blank">tokenizer_config.json</a>.
-
-If you'd like to dive even deeper into the fascinating world of language models and natural language processing, don't hesitate to check out our <a href="https://huggingface.co/learn/nlp-course/chapter1/1" target="_blank">free NLP course</a>.


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/bbd50a5f-7ffe-4eb2-b2b5-b0727d61916c)
(from: https://huggingface.co/learn/agents-course/unit1/what-are-llms)

The same sentence referring to the free LLM course from HuggingFace was in two different places of the same section. Removed the redundant line.

The two lines are [Line 225](https://github.com/huggingface/agents-course/blob/main/units/en/unit1/what-are-llms.mdx?plain=1#L225) and [Line 215](https://github.com/huggingface/agents-course/blob/main/units/en/unit1/what-are-llms.mdx?plain=1#L215).

Both lines state:

> If you'd like to dive even deeper into the fascinating world of language models and natural language processing, don't hesitate to check out our <a href="https://huggingface.co/learn/nlp-course/chapter1/1" target="_blank">free NLP course</a>.

And they both are in the same section. I think this was done by mistake.

I removed the sentence on Line 225, but kept the one on 215, because the previous line ([Line 213](https://github.com/huggingface/agents-course/blob/main/units/en/unit1/what-are-llms.mdx?plain=1#L213)) says that:

> That was a lot of information! We've covered the basics of what LLMs are, how they function, and their role in powering AI agents. 

So, I think, in the cases of two lines, the first line (215) has the business to stay, and line last line (225) should go.