### PR TITLE
fix: Update Meta Llama model link to full Hugging Face URL

### DIFF
--- a/units/en/unit1/what-are-llms.mdx
+++ b/units/en/unit1/what-are-llms.mdx
@@ -218,7 +218,7 @@ Now that we understand how LLMs work, it's time to see **how LLMs structure thei
 
 To run this notebook, **you need a Hugging Face token** that you can get from <a href="https://hf.co/settings/tokens" target="_blank">https://hf.co/settings/tokens</a>.
 
-You also need to request access to <a href="meta-llama/Llama-3.2-3B-Instruct" target="_blank">the Meta Llama models</a>
+You also need to request access to <a href="https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct" target="_blank">the Meta Llama models</a>
 
 For example, you can find the special tokens of the SmollLM2 model in its <a href="https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct/blob/main/tokenizer_config.json" target="_blank">tokenizer_config.json</a>.
 


### PR DESCRIPTION
Resolves 404 error by pointing to the correct model page: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct