### PR TITLE
fix(tools.mdx): Align text with Python code

### DIFF
--- a/units/en/unit1/tools.mdx
+++ b/units/en/unit1/tools.mdx
@@ -190,7 +190,7 @@ It may seem complicated, but if we go slowly through it we can see what it does.
 - **`name`** (*str*): The name of the tool.
 - **`description`** (*str*): A brief description of what the tool does.
 - **`function`** (*callable*): The function the tool executes.
-- **`input_arguments`** (*list*): The expected input parameters.
+- **`arguments`** (*list*): The expected input parameters.
 - **`outputs`** (*str* or *list*): The expected outputs of the tool.
 - **`__call__()`**: Calls the function when the tool instance is invoked.
 - **`to_string()`**: Converts the tool's attributes into a textual representation.


### PR DESCRIPTION
Replace "input_arguments" with "arguments" to reflect the definition of class Tool