### PR TITLE
fix: Remove duplicate tokenizer reference from document end

### DIFF
--- a/units/en/unit1/what-are-llms.mdx
+++ b/units/en/unit1/what-are-llms.mdx
@@ -219,5 +219,3 @@ Now that we understand how LLMs work, it's time to see **how LLMs structure thei
 To run this notebook, **you need a Hugging Face token** that you can get from <a href="https://hf.co/settings/tokens" target="_blank">https://hf.co/settings/tokens</a>.
 
 You also need to request access to <a href="https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct" target="_blank">the Meta Llama models</a>
-
-For example, you can find the special tokens of the SmollLM2 model in its <a href="https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct/blob/main/tokenizer_config.json" target="_blank">tokenizer_config.json</a>.


### PR DESCRIPTION
Removes misplaced line about SmolLM2 tokenizer config that was already mentioned in the Tips section earlier in the document. This improves the natural flow of the conclusion and setup instructions.