### PR TITLE
[FIX] Fix documentation inconsistency in Dummy Agent Library examples

### DIFF
--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -211,8 +211,8 @@ Action:
   "action_input": {"location": "London"}
 }
 ```
-Thought: I will check the weather in London.
-Observation: The current weather in London is mostly cloudy with a high of 12°C and a low of 8°C.
+Observation: The current weather in London is mostly cloudy with a high of 12°C and a low of 6°C, with a gentle breeze from the west at 15 km/h.
+Thought: I now know the current weather in London.
 ````
 
 Do you see the issue?
@@ -238,7 +238,6 @@ Action:
   "action_input": {"location": "London"}
 }
 ```
-Thought: I will check the weather in London.
 Observation:
 ````
 
@@ -307,16 +306,14 @@ Now begin! Reminder to ALWAYS use the exact characters `Final Answer:` when you 
 <|eot_id|><|start_header_id|>user<|end_header_id|>
 What's the weather in London ?
 <|eot_id|><|start_header_id|>assistant<|end_header_id|>
-
 Action:
 ```
 {
   "action": "get_weather",
-  "action_input": {"location": {"type": "string", "value": "London"}
+  "action_input": {"location": "London"}
 }
 ```
-Thought: I will check the weather in London.
-Observation:the weather in London is sunny with low temperatures. 
+Observation: the weather in London is sunny with low temperatures. 
 ````
 
 Output:


### PR DESCRIPTION
The documentation on the [Dummy Agent Library](https://huggingface.co/learn/agents-course/unit1/dummy-agent-library) page contains an inconsistency between the system prompt template and the expected model output.

### **Problem**
The prompt template specifies that the model should first generate a "Thought" before an "Action".
However, the example output shown in the documentation displays the "Action" first, followed by the "Thought".
It can be misleading, as it suggests that "Action" should come first, contradicting the system prompt instructions.

### **Fix**
Change the examples output to expected outputs

Please let me know if you need any further changes or if anything in the pull request doesn't look good to you.