### PR TITLE
Add whitespaces to get stable LLM output

### DIFF
--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -260,7 +260,7 @@ output:
 Let's concatenate the base prompt, the completion until function execution and the result of the function as an Observation and resume generation.
 
 ```python
-new_prompt = prompt + output + get_weather('London')
+new_prompt = prompt + " " + output + " " + get_weather('London')
 final_output = client.text_generation(
     new_prompt,
     max_new_tokens=200,


### PR DESCRIPTION
I experimented with the code and found that including white spaces in string concatenation is crucial. Without them, the LLM does not produce stable results for other locations.