### PR TITLE
Change output of text_generation

### DIFF
--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -46,7 +46,7 @@ print(output)
 ```
 output:
 ```
-Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris.
+Paris. The capital of Italy is Rome. The capital of Spain is Madrid. The capital of Germany is Berlin. The capital of the United Kingdom is London. The capital of Australia is Canberra. The capital of China is Beijing. The capital of Japan is Tokyo. The capital of India is New Delhi. The capital of Brazil is Brasília. The capital of Russia is Moscow. The capital of South Africa is Pretoria. The capital of Egypt is Cairo. The capital of Turkey is Ankara. The
 ```
 As seen in the LLM section, if we just do decoding, **the model will only stop when it predicts an EOS token**, and this does not happen here because this is a conversational (chat) model and **we didn't apply the chat template it expects**.
 


### PR DESCRIPTION
Different output observed for first example of text_generation output. Instead of "The capital of France is Paris." repeated multiple times, the output lists the capitals of multiple countries.