### PR TITLE
Eliminate duplicated 'the' in Bonus Unit 1

### DIFF
--- a/units/en/bonus-unit1/what-is-function-calling.mdx
+++ b/units/en/bonus-unit1/what-is-function-calling.mdx
@@ -10,7 +10,7 @@ While here, **with function-calling, the Agent is fine-tuned (trained) to use To
 
 ## How does the model "learn" to take an action?
 
-In Unit 1, we explored the general workflow of an agent. Once the the user has given some tools to the agent and prompted it with a query, the model will cycle through:
+In Unit 1, we explored the general workflow of an agent. Once the user has given some tools to the agent and prompted it with a query, the model will cycle through:
 
 1. *Think* : What action(s) do I need to take in order to fulfill the objective.
 2. *Act* : Format the action with the correct parameter and stop the generation.


### PR DESCRIPTION
Eliminated duplicated 'the' from "Once the the user has given some tools to the agent and prompted it with a query, the model will cycle through:"