### PR TITLE
[FIX]  a minor typo in bonus-unit1/bonus-unit1.ipynb

### DIFF
--- a/notebooks/bonus-unit1/gemma-SFT-thinking-function_call.ipynb
+++ b/notebooks/bonus-unit1/gemma-SFT-thinking-function_call.ipynb
@@ -339,7 +339,7 @@
     "\n",
     "1. A *User message* containing the **necessary information with the list of available tools** inbetween `<tools></tools>` then the user query, here:  `\"Can you get me the latest news headlines for the United States?\"`\n",
     "\n",
-    "2. An *Assistant message* here called \"model\" to fit the criterias from gemma models containing two new phases, a **\"thinking\"** phase contained in `<think></think>` and an **\"Act\"** phase contained in `<tool_call></<tool_call>`.\n",
+    "2. An *Assistant message* here called \"model\" to fit the criterias from gemma models containing two new phases, a **\"thinking\"** phase contained in `<think></think>` and an **\"Act\"** phase contained in `<tool_call></tool_call>`.\n",
     "\n",
     "3. If the model contains a `<tools_call>`, we will append the result of this action in a new **\"Tool\"** message containing a `<tool_response></tool_response>` with the answer from the tool."
    ]


### PR DESCRIPTION
The original code mistakenly included an extra '<' character in the tool_call tag, which could have caused misunderstanding.