### PR TITLE
[FIX] A XML syntax and enum value typos in Bonus Unit 1 notebook

### DIFF
--- a/notebooks/bonus-unit1/gemma-SFT-thinking-function_call.ipynb
+++ b/notebooks/bonus-unit1/gemma-SFT-thinking-function_call.ipynb
@@ -463,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "833ba5d6-4c1e-4689-9fed-22cc03d2a63a",
    "metadata": {
     "colab": {

--- a/notebooks/bonus-unit1/gemma-SFT-thinking-function_call.ipynb
+++ b/notebooks/bonus-unit1/gemma-SFT-thinking-function_call.ipynb
@@ -339,7 +339,7 @@
     "\n",
     "1. A *User message* containing the **necessary information with the list of available tools** inbetween `<tools></tools>` then the user query, here:  `\"Can you get me the latest news headlines for the United States?\"`\n",
     "\n",
-    "2. An *Assistant message* here called \"model\" to fit the criterias from gemma models containing two new phases, a **\"thinking\"** phase contained in `<think></think>` and an **\"Act\"** phase contained in `<tool_call></<tool_call>`.\n",
+    "2. An *Assistant message* here called \"model\" to fit the criterias from gemma models containing two new phases, a **\"thinking\"** phase contained in `<think></think>` and an **\"Act\"** phase contained in `<tool_call></tool_call>`.\n",
     "\n",
     "3. If the model contains a `<tools_call>`, we will append the result of this action in a new **\"Tool\"** message containing a `<tool_response></tool_response>` with the answer from the tool."
    ]

--- a/notebooks/bonus-unit1/gemma-SFT-thinking-function_call.ipynb
+++ b/notebooks/bonus-unit1/gemma-SFT-thinking-function_call.ipynb
@@ -463,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "833ba5d6-4c1e-4689-9fed-22cc03d2a63a",
    "metadata": {
     "colab": {
@@ -621,8 +621,8 @@
     "    eothink = \"</think>\"\n",
     "    tool_call=\"<tool_call>\"\n",
     "    eotool_call=\"</tool_call>\"\n",
-    "    tool_response=\"<tool_reponse>\"\n",
-    "    eotool_response=\"</tool_reponse>\"\n",
+    "    tool_response=\"<tool_response>\"\n",
+    "    eotool_response=\"</tool_response>\"\n",
     "    pad_token = \"<pad>\"\n",
     "    eos_token = \"<eos>\"\n",
     "    @classmethod\n",


### PR DESCRIPTION
**1. Malformed XML closing tag (Step7)**  
In the markdown cell:  
❌ Incorrect: `</<tool_call>` (extra opening angle bracket)  
✅ Fixed: `</tool_call>`


**2. Value typos (Step8)**  
In `ChatmlSpecialTokens` definition:  

❌ Original typos:  
```
tool_response="<tool_reponse>",  # Missing 's'
eotool_response="</tool_reponse>"  # Missing 's'
```
✅ Corrected to:
```
tool_response="<tool_response>",
eotool_response="</tool_response>"
```