### PR TITLE
Proposed adding details to HF token setup and minor typo

### DIFF
--- a/notebooks/unit1/dummy_agent_library.ipynb
+++ b/notebooks/unit1/dummy_agent_library.ipynb
@@ -40,7 +40,9 @@
     "\n",
     "In the Hugging Face ecosystem, there is a convenient feature called Serverless API that allows you to easily run inference on many models. There's no installation or deployment required.\n",
     "\n",
-    "To run this notebook, **you need a Hugging Face token** that you can get from https://hf.co/settings/tokens. If you are running this notebook on Google Colab, you can set it up in the \"settings\" tab under \"secrets\". Make sure to call it \"HF_TOKEN\".\n",
+    "To run this notebook, **you need a Hugging Face token** that you can get from https://hf.co/settings/tokens. A \"Read\" token type is sufficient. \n",
+    "- If you are running this notebook on Google Colab, you can set it up in the \"settings\" tab under \"secrets\". Make sure to call it \"HF_TOKEN\" and restart the session to load the environment variable (Runtime -> Restart session).\n",
+    "- If you are running this notebook locally, you can set it up as an [environment variable](https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables). Make sure you restart the kernel after installing or updating huggingface_hub. You can update huggingface_hub by modifying the above `!pip install -q huggingface_hub -U`\n",
     "\n",
     "You also need to request access to [the Meta Llama models](https://huggingface.co/meta-llama), select [Llama-3.2-3B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct) if you haven't done it click on Expand to review and access and fill the form. Approval usually takes up to an hour."
    ]
@@ -506,7 +508,7 @@
    "source": [
     "Much Better!\n",
     "\n",
-    "Let's now create a **dummy get weather function**. In a real situation you could call and API."
+    "Let's now create a **dummy get weather function**. In a real situation you could call an API."
    ]
   },
   {


### PR DESCRIPTION
I proposed a few changes to the unit 1 notebook instructions after running into a few friction points trying the notebook on colab and locally, in case anyone else runs into the same issues. Thanks for putting together this course for the community!

Proposed changes:
- There have been a few questions on discord and an issue asking what settings are needed for HF token (proposed adding "Read token is sufficient" based on [response from discord](https://discord.com/channels/879548962464493619/1340445192091598858/1340445192091598858))
- Added a link to the docs on setting up environment variables
-  Proposed adding instructions to update huggingface_hub if running locally `!pip install -q huggingface_hub -U`. I had 0.20.1 and couldn't run the chat method until I updated (AttributeError: 'InferenceClient' object has no attribute 'chat') which took me a bit to figure out
- add a note to restart the kernel after you add the HF_TOKEN to secrets (when I added it to colab I kept getting the error until I restarted the kernel, which make sense but took me a minute to figure out so thought might be helpful to specify). 
- Typo "and API"