### PR TITLE
fix #236: Click on the link to jump to the corresponding chapter of the corresponding text.

### DIFF
--- a/units/en/unit1/messages-and-special-tokens.mdx
+++ b/units/en/unit1/messages-and-special-tokens.mdx
@@ -181,7 +181,7 @@ A chat template structures conversations between users and AI models...<|im_end|
 How do I use it ?<|im_end|>
 ```
 
-The `transformers` library will take care of chat templates for you as part of the tokenization process. Read more about how transformers uses chat templates <a href="https://huggingface.co/docs/transformers/en/chat_templating#how-do-i-use-chat-templates" target="_blank">here</a>. All we have to do is structure our messages in the correct way and the tokenizer will take care of the rest.
+The `transformers` library will take care of chat templates for you as part of the tokenization process. Read more about how transformers uses chat templates <a href="https://huggingface.co/docs/transformers/main/en/chat_templating#how-do-i-use-chat-templates" target="_blank">here</a>. All we have to do is structure our messages in the correct way and the tokenizer will take care of the rest.
 
 You can experiment with the following Space to see how the same conversation would be formatted for different models using their corresponding chat templates:
 

--- a/units/zh-CN/unit1/messages-and-special-tokens.mdx
+++ b/units/zh-CN/unit1/messages-and-special-tokens.mdx
@@ -182,7 +182,7 @@ A chat template structures conversations between users and AI models...<|im_end|
 How do I use it ?<|im_end|>
 ```
 
-`transformers`库会将聊天模板作为标记化过程的一部分为你处理。在<a href="https://huggingface.co/docs/transformers/en/chat_templating#how-do-i-use-chat-templates" target="_blank">这里</a>阅读更多关于 transformers 如何使用聊天模板的信息。我们要做的就是以正确的方式构建我们的消息，标记器将处理剩下的事情。
+`transformers`库会将聊天模板作为标记化过程的一部分为你处理。在<a href="https://huggingface.co/docs/transformers/main/en/chat_templating#how-do-i-use-chat-templates" target="_blank">这里</a>阅读更多关于 transformers 如何使用聊天模板的信息。我们要做的就是以正确的方式构建我们的消息，标记器将处理剩下的事情。
 
 你可以使用以下Space实验，看看同样的对话如何使用不同模型的相应聊天模板进行格式化：
 


### PR DESCRIPTION
Fix #236 
Click on the link to jump to the corresponding chapter of the corresponding text.

![image](https://github.com/user-attachments/assets/4094131f-70a9-40bf-93ca-e2526dc27892)
