### PR TITLE
fix: missing telemetry dependency in agent course notebook

### DIFF
--- a/notebooks/unit2/smolagents/code_agents.ipynb
+++ b/notebooks/unit2/smolagents/code_agents.ipynb
@@ -4575,7 +4575,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install opentelemetry-sdk opentelemetry-exporter-otlp openinference-instrumentation-smolagents"
+        "!pip install smolagents[telemetry] opentelemetry-sdk opentelemetry-exporter-otlp openinference-instrumentation-smolagents"
       ]
     },
     {


### PR DESCRIPTION
Resolves https://github.com/langfuse/langfuse/issues/5720