### PR TITLE
[FIX] Bug Fix: Model Generates Invalid Output with max_new_tokens=200

### DIFF
--- a/notebooks/unit1/dummy_agent_library.ipynb
+++ b/notebooks/unit1/dummy_agent_library.ipynb
@@ -460,7 +460,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "9fc783f2-66ac-42cf-8a57-51788f81d436",
    "metadata": {
     "colab": {
@@ -492,7 +492,7 @@
     "# The answer was hallucinated by the model. We need to stop to actually execute the function!\n",
     "output = client.text_generation(\n",
     "    prompt,\n",
-    "    max_new_tokens=200,\n",
+    "    max_new_tokens=150,\n",
     "    stop=[\"Observation:\"] # Let's stop before any actual function is called\n",
     ")\n",
     "\n",


### PR DESCRIPTION
Bug Fix: Model Generates Invalid Output with max_new_tokens=200

I've identified and fixed an issue in the dummy_agent_library.ipynb notebook where using max_new_tokens=200 in the text generation call consistently produces an invalid output consisting only of tick marks as it can be seen below:

![generationFalse](https://github.com/user-attachments/assets/8ea78fa2-a732-4cd0-8b29-1ce05a382490)

This behavior is reproducible on every execution with this specific value in the current version of the notebook.

I do not know the exact reason but apparently changing the max_new_token from 200 to 150 solves the problem. (Actually changing 200 to some other value like 160 or 210 also fixes the error, the error persists only when it is set to 200). 

This appears to be a model or implementation -specific edge case where this particular token count triggers unexpected behavior in the response generation. The corrected version and the output looks like:

![generationTrue](https://github.com/user-attachments/assets/eeb3bd8f-82d8-4310-b017-e3951db6cad8)
