### PR TITLE
[Fix] link in what-are-agents.mdx to what-are-llms results in 404

### DIFF
--- a/units/en/unit1/what-are-agents.mdx
+++ b/units/en/unit1/what-are-agents.mdx
@@ -143,4 +143,4 @@ To summarize, an Agent is a system that uses an AI Model (typically an LLM) as i
 
 - **Interact with its environment:** Gather information, take actions, and observe the results of those actions.
 
-Now that you have a solid grasp of what Agents are, let’s reinforce your understanding with a short, ungraded quiz. After that, we’ll dive into the “Agent’s brain”: the [LLMs](what-are-llms.mdx).
+Now that you have a solid grasp of what Agents are, let’s reinforce your understanding with a short, ungraded quiz. After that, we’ll dive into the “Agent’s brain”: the [LLMs](what-are-llms).


### PR DESCRIPTION
Link contained "mdx" extension that should not be used in the link (as it results in a 404).