### PR TITLE
Fix the name of the zero-shot CoT approach

### DIFF
--- a/units/en/unit1/README.md
+++ b/units/en/unit1/README.md
@@ -11,7 +11,7 @@ You can access Unit 1 on hf.co/learn 👉 <a href="https://hf.co/learn/agents-co
 | [Dummy Agent Library](4_dummy_agent_library.md) | Introduction to using a dummy agent library and serverless API. |
 | [Tools](5_tools.md) | Overview of Pydantic for agent tools and other common tool formats. |
 | [Agent Steps and Structure](6_agent_steps_and_structure.md) | Steps involved in an agent, including thoughts, actions, observations, and a comparison between code agents and JSON agents. |
-| [Thoughts](7_thoughts.md) | Explanation of thoughts and the ReAct approach. |
+| [Thoughts](7_thoughts.md) | Explanation of thoughts and the Zero-shot CoT approach. |
 | [Actions](8_actions.md) | Overview of actions and stop and parse approach. |
 | [Observations](9_observations.md) | Explanation of observations and append result to reflect. |
 | [Quizz](10_quizz.md) | Contains quizzes to test understanding of the concepts. |

--- a/units/en/unit1/thoughts.mdx
+++ b/units/en/unit1/thoughts.mdx
@@ -30,26 +30,25 @@ Here are some examples of common thoughts:
 > **Note:** In the case of LLMs fine-tuned for function-calling, the thought process is optional.
 > *In case you're not familiar with function-calling, there will be more details in the Actions section.*
 
-## The Re-Act Approach
+## The Zero-shot CoT Approach
 
-A key method is the **ReAct approach**, which is the concatenation of  "Reasoning" (Think) with "Acting" (Act). 
+A key method is the **Zero-shot CoT approach**, where CoT stands for **Chain of Thought**.
 
-ReAct is a simple prompting technique that appends "Let's think step by step" before letting the LLM decode the next tokens. 
+Zero-shot CoT approach is a simple prompting technique that appends "Let's think step by step" before letting the LLM decode the next tokens. 
 
 Indeed, prompting the model to think "step by step" encourages the decoding process toward next tokens **that generate a plan**, rather than a final solution, since the model is encouraged to **decompose** the problem into *sub-tasks*.
 
 This allows the model to consider sub-steps in more detail, which in general leads to less errors than trying to generate the final solution directly.
 
 <figure>
-<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit1/ReAct.png" alt="ReAct"/>
-<figcaption>The (d) is an example of Re-Act approach where we prompt "Let's think step by step"
-</figcaption>
+<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit1/ReAct.png" alt="CoT"/>
+<figcaption>The (d) is an example of the Zero-shot CoT approach approach where we prompt "Let's think step by step"</figcaption>
 </figure>
 
 <Tip>
 We have recently seen a lot of interest for reasoning strategies. This is what's behind models like Deepseek R1 or OpenAI's o1, which have been fine-tuned to "think before answering".
 
-These models have been trained to always include specific _thinking_ sections (enclosed between `<think>` and `</think>` special tokens). This is not just a prompting technique like ReAct, but a training method where the model learns to generate these sections after analyzing thousands of examples that show what we expect it to do.
+These models have been trained to always include specific _thinking_ sections (enclosed between `<think>` and `</think>` special tokens). This is not just a prompting technique like zero-shot CoT, but a training method where the model learns to generate these sections after analyzing thousands of examples that show what we expect it to do.
 </Tip>
 
 --- 


### PR DESCRIPTION
In Unit 1 the method described as ReAct does not correspond to the ReAct approach but to the Zero-shot Chain of Thought approach, as described in this paper https://arxiv.org/pdf/2205.11916 where the image illustrating the approach comes from (page 2).

ReAct is a more complex approach described in https://arxiv.org/pdf/2210.03629 which consists in forcing the LLM to alternate between Reasoning and Acting steps by using few-shot examples following this mechanism.