### PR TITLE
Fix 278: Edit vector database definition in Unit2.1 retrieval_agents.mdx

### DIFF
--- a/units/en/unit2/smolagents/retrieval_agents.mdx
+++ b/units/en/unit2/smolagents/retrieval_agents.mdx
@@ -62,7 +62,7 @@ The agent follows this process:
 
 For specialized tasks, a custom knowledge base can be invaluable. Let's create a tool that queries a vector database of technical documentation or specialized knowledge. Using semantic search, the agent can find the most relevant information for Alfred's needs.
 
-A vector database is just a collection of documents with rich representations by specialist ML models, that allow for fast search and retrieval of the documents. 
+A vector database stores numerical representations (embeddings) of text or other data, created by machine learning models. It enables semantic search by identifying similar meanings in high-dimensional space.
 
 This approach combines predefined knowledge with semantic search to provide context-aware solutions for event planning. With specialized knowledge access, Alfred can perfect every detail of the party.
 


### PR DESCRIPTION
Fixes #278 
Revised the vector database definition in the _Custom Knowledge Base Tool_ section.