### PR TITLE
Fix Markdown links inside custom HTML components

### DIFF
--- a/units/en/unit2/smolagents/code_agents.mdx
+++ b/units/en/unit2/smolagents/code_agents.mdx
@@ -304,7 +304,7 @@ As you can see, we've created a `CodeAgent` with several tools that enhance the 
 Now, it's your turn: build your very own agent and share it with the community using the knowledge we've just learned! 🕵️‍♂️💡
 
 <Tip>
-If you would like to share your agent project, then make a space and tag the [agents-course](https://huggingface.co/agents-course) on the Hugging Face Hub. We'd love to see what you've created!
+If you would like to share your agent project, then make a space and tag the <a href="https://huggingface.co/agents-course">agents-course</a> on the Hugging Face Hub. We'd love to see what you've created!
 </Tip>
 
 ### Inspecting Our Party Preparator Agent with OpenTelemetry and Langfuse 📡
@@ -366,7 +366,7 @@ alfred_agent.run("Give me the best playlist for a party at Wayne's mansion. The 
 Alfred can now access these logs [here](https://cloud.langfuse.com/project/cm7bq0abj025rad078ak3luwi/traces/995fc019255528e4f48cf6770b0ce27b?timestamp=2025-02-19T10%3A28%3A36.929Z) to review and analyze them.  
 
 <Tip>
-Actually, a minor error occured during execution. Can you spot it in the logs? Try to track how the agent handles it and still returns a valid answer. [Here](https://cloud.langfuse.com/project/cm7bq0abj025rad078ak3luwi/traces/995fc019255528e4f48cf6770b0ce27b?timestamp=2025-02-19T10%3A28%3A36.929Z&observation=80ca57ace4f69b52) is the direct link to the error if you want to verify your answer. Of course the error has been fixed in the meantime, more details can be found in this [issue](https://cloud.langfuse.com/project/cm7bq0abj025rad078ak3luwi/traces/995fc019255528e4f48cf6770b0ce27b?timestamp=2025-02-19T10%3A28%3A36.929Z&observation=80ca57ace4f69b52).
+Actually, a minor error occured during execution. Can you spot it in the logs? Try to track how the agent handles it and still returns a valid answer. <a href="https://cloud.langfuse.com/project/cm7bq0abj025rad078ak3luwi/traces/995fc019255528e4f48cf6770b0ce27b?timestamp=2025-02-19T10%3A28%3A36.929Z&observation=80ca57ace4f69b52">Here</a> is the direct link to the error if you want to verify your answer. Of course the error has been fixed in the meantime, more details can be found in this [issue](https://cloud.langfuse.com/project/cm7bq0abj025rad078ak3luwi/traces/995fc019255528e4f48cf6770b0ce27b?timestamp=2025-02-19T10%3A28%3A36.929Z&observation=80ca57ace4f69b52).
 </Tip>
 
 Meanwhile, the [suggested playlist](https://open.spotify.com/playlist/0gZMMHjuxMrrybQ7wTMTpw) sets the perfect vibe for the party preparations. Cool, right? 🎶  


### PR DESCRIPTION
Fixed an issue where Markdown links weren't rendering correctly inside `<Tip>` components by replacing them with HTML anchor tags for better compatibility.