### PR TITLE
Fixes url to send the reader to the correct page

### DIFF
--- a/units/en/unit2/smolagents/code_agents.mdx
+++ b/units/en/unit2/smolagents/code_agents.mdx
@@ -42,7 +42,7 @@ A `CodeAgent` performs actions through a cycle of steps, with existing variables
 
 2. Then, the following while loop is executed:
 
-    2.1 Method `agent.write_memory_to_messages()` writes the agent's logs into a list of LLM-readable [chat messages](https://huggingface.co/docs/transformers/en/chat_templating).  
+    2.1 Method `agent.write_memory_to_messages()` writes the agent's logs into a list of LLM-readable [chat messages](https://huggingface.co/docs/transformers/main/en/chat_templating).
     
     2.2 These messages are sent to a `Model`, which generates a completion. 
     


### PR DESCRIPTION
Link was redirecting to an incorrect path. This should fix that. 