### PR TITLE
Update code_agents.mdx to avoid a function name conflict

### DIFF
--- a/units/en/unit2/smolagents/code_agents.mdx
+++ b/units/en/unit2/smolagents/code_agents.mdx
@@ -42,7 +42,7 @@ A `CodeAgent` performs actions through a cycle of steps, with existing variables
 
 2. Then, the following while loop is executed:
 
-    2.1 Method `agent.write_memory_to_messages()` writes the agent's logs into a list of LLM-readable [chat messages](https://huggingface.co/docs/transformers/main/en/chat_templating).
+    2.1 Method `agent.write_inner_memory_from_logs()` writes the agent's logs into a list of LLM-readable [chat messages](https://huggingface.co/docs/transformers/main/en/chat_templating).
     
     2.2 These messages are sent to a `Model`, which generates a completion. 
     


### PR DESCRIPTION
In the description of where CodeAgent.run workflow is explained, the function name is ambiguous and potentially misaligning with what's written in the image. Changing that to `write_inner_memory_from_logs` from `write_memory_to_messages`