### PR TITLE
2.3 LangGraph: Fix notebook link in first_graph.mdx

### DIFF
--- a/units/en/unit2/langgraph/first_graph.mdx
+++ b/units/en/unit2/langgraph/first_graph.mdx
@@ -10,7 +10,7 @@ Now that we understand the building blocks, let's put them into practice by buil
 This example demonstrates how to structure a workflow with LangGraph that involves LLM-based decision-making. While this can't be considered an Agent as no tool is involved, this section focuses more on learning the LangGraph framework than Agents.
 
 <Tip>
-You can follow the code in <a href="https://huggingface.co/agents-course/notebooks/resolve/main/unit2/langgraph/mail_sorting.ipynb" target="_blank">this notebook</a> that you can run using Google Colab.
+You can follow the code in <a href="https://huggingface.co/agents-course/notebooks/blob/main/unit2/langgraph/mail_sorting.ipynb" target="_blank">this notebook</a> that you can run using Google Colab.
 </Tip>
 ## Our Workflow
 


### PR DESCRIPTION
The suggested "this notebook" link in https://huggingface.co/learn/agents-course/unit2/langgraph/first_graph is incorrect.
Google Colab won't open it.

The path here should be ../notebooks/**blob**..
rather than ../notebooks/**resolve**..

![image](https://github.com/user-attachments/assets/a8647275-7cf8-4817-8e31-52da62e76df4)
