### PR TITLE
Add newline before "Our Workflow" header

### DIFF
--- a/units/en/unit2/langgraph/first_graph.mdx
+++ b/units/en/unit2/langgraph/first_graph.mdx
@@ -12,6 +12,7 @@ This example demonstrates how to structure a workflow with LangGraph that involv
 <Tip>
 You can follow the code in <a href="https://huggingface.co/agents-course/notebooks/resolve/main/unit2/langgraph/mail_sorting.ipynb" target="_blank">this notebook</a> that you can run using Google Colab.
 </Tip>
+
 ## Our Workflow
 
 Here's the workflow we'll build:


### PR DESCRIPTION
Added newline to make header render correctly.

---

### After Update:
![image](https://github.com/user-attachments/assets/70b8f6e6-9d51-416f-98ff-331bd0492990)

---

### Before:
![image](https://github.com/user-attachments/assets/4550da2e-0fee-46d3-886c-e23901a6a5be)
