### PR TITLE
Update monitoring-and-evaluating-agents.ipynb

### DIFF
--- a/notebooks/bonus-unit2/monitoring-and-evaluating-agents.ipynb
+++ b/notebooks/bonus-unit2/monitoring-and-evaluating-agents.ipynb
@@ -257,10 +257,10 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from smolagents import (CodeAgent, GoogleSearchTool, HfApiModel)\n",
+        "from smolagents import (CodeAgent, DuckDuckGoSearchTool, HfApiModel)\n",
         "from opentelemetry import trace\n",
         "\n",
-        "search_tool = GoogleSearchTool()\n",
+        "search_tool = DuckDuckGoSearchTool()\n",
         "agent = CodeAgent(\n",
         "    tools=[search_tool],\n",
         "    model=HfApiModel()\n",


### PR DESCRIPTION
GoogleSearchTool requires an API key (which is not defined in this file). It is simpler to continue using DuckDuckGoSearchTool as the search tool.