### PR TITLE
Add "agency" table to what-are-agents.mdx

### DIFF
--- a/units/en/unit1/what-are-agents.mdx
+++ b/units/en/unit1/what-are-agents.mdx
@@ -62,6 +62,21 @@ This part represents **everything the Agent is equipped to do**.
 
 The **scope of possible actions** depends on what the agent **has been equipped with**. For example, because humans lack wings, they can't perform the "fly" **Action**, but they can execute **Actions** like "walk", "run" ,"jump", "grab", and so on.
 
+### The spectrum of "Agency"
+
+Following this definition, Agents exist on a continuous spectrum of increasing agency:
+
+| Agency Level | Description | What that's called | Example pattern |
+| --- | --- | --- | --- |
+| ☆☆☆ | Agent output has no impact on program flow | Simple processor | `process_llm_output(llm_response)` |
+| ★☆☆ | Agent output determines basic control flow | Router | `if llm_decision(): path_a() else: path_b()` |
+| ★★☆ | Agent output determines function execution | Tool caller | `run_function(llm_chosen_tool, llm_chosen_args)` |
+| ★★★ | Agent output controls iteration and program continuation | Multi-step Agent | `while llm_should_continue(): execute_next_step()` |
+| ★★★ | One agentic workflow can start another agentic workflow | Multi-Agent | `if llm_trigger(): execute_agent()` |
+
+Table from [smolagents conceptual guide](https://huggingface.co/docs/smolagents/conceptual_guides/intro_agents).
+
+
 ## What type of AI Models do we use for Agents?
 
 The most common AI model found in Agents is an LLM (Large Language Model), which  takes **Text** as an input and outputs **Text** as well.


### PR DESCRIPTION
This adds the "agency" table developed for smolagents. Ethics & society regulars further adapted this table as well, in case you want to use that one (with credit to the fantastic original) -- see here: https://huggingface.co/blog/ethics-soc-7#overview We:
- Removed "multi-agent" and instead say that these different levels can be combined in multi-agent systems.
- Added "fully autonomous".

Note that we're using the term "autonomy" instead of "agency". We explain more of why in our paper: https://arxiv.org/abs/2502.02649 but the tl;dr is that "agency" is by definition a human term, "autonomy" is more in line with what it means when a computer does it.