### PR TITLE
Update mcp tools sample code

### DIFF
--- a/units/en/unit2/smolagents/tools.mdx
+++ b/units/en/unit2/smolagents/tools.mdx
@@ -292,7 +292,7 @@ server_parameters = StdioServerParameters(
     env={"UV_PYTHON": "3.12", **os.environ},
 )
 
-with ToolCollection.from_mcp(server_parameters) as tool_collection:
+with ToolCollection.from_mcp(server_parameters, trust_remote_code=True) as tool_collection:
     agent = CodeAgent(tools=[*tool_collection.tools], model=model, add_base_tools=True)
     agent.run("Please find a remedy for hangover.")
 ```

--- a/units/en/unit2/smolagents/tools.mdx
+++ b/units/en/unit2/smolagents/tools.mdx
@@ -280,15 +280,20 @@ The MCP servers tools can be loaded in a ToolCollection object as follow:
 import os
 from smolagents import ToolCollection, CodeAgent
 from mcp import StdioServerParameters
+from smolagents import HfApiModel
+
+
+model = HfApiModel("Qwen/Qwen2.5-Coder-32B-Instruct")
+
 
 server_parameters = StdioServerParameters(
-    command="uv",
+    command="uvx",
     args=["--quiet", "pubmedmcp@0.1.3"],
     env={"UV_PYTHON": "3.12", **os.environ},
 )
 
 with ToolCollection.from_mcp(server_parameters) as tool_collection:
-    agent = CodeAgent(tools=[*tool_collection.tools], add_base_tools=True)
+    agent = CodeAgent(tools=[*tool_collection.tools], model=model, add_base_tools=True)
     agent.run("Please find a remedy for hangover.")
 ```
 


### PR DESCRIPTION
model is required positional argument

current sample on running shows the following error on keyboard interrupt

```
---------------------------------------------------------------------------
KeyboardInterrupt                         Traceback (most recent call last)
Cell In[16], line 11
      3 from mcp import StdioServerParameters
      5 server_parameters = StdioServerParameters(
      6     command="uv",
      7     args=["--quiet", "pubmedmcp@0.1.3"],
      8     env={"UV_PYTHON": "3.12", **os.environ},
      9 )
---> 11 with ToolCollection.from_mcp(server_parameters) as tool_collection:
     12     agent = CodeAgent(tools=[*tool_collection.tools], add_base_tools=True)
     13     agent.run("Please find a remedy for hangover.")

File [/usr/lib/python3.10/contextlib.py:135](http://jupyterhub:8888/usr/lib/python3.10/contextlib.py#line=134), in _GeneratorContextManager.__enter__(self)
    133 del self.args, self.kwds, self.func
    134 try:
--> 135     return next(self.gen)
    136 except StopIteration:
    137     raise RuntimeError("generator didn't yield") from None

File ~/.local/lib/python3.10/site-packages/smolagents/tools.py:833, in ToolCollection.from_mcp(cls, server_parameters)
    828 except ImportError:
    829     raise ImportError(
    830         """Please install 'mcp' extra to use ToolCollection.from_mcp: `pip install "smolagents[mcp]"`."""
    831     )
--> 833 with MCPAdapt(server_parameters, SmolAgentsAdapter()) as tools:
    834     yield cls(tools)
```