### PR TITLE
Typo of uv instead of uvx

### DIFF
--- a/units/en/unit2/smolagents/tools.mdx
+++ b/units/en/unit2/smolagents/tools.mdx
@@ -282,7 +282,7 @@ from smolagents import ToolCollection, CodeAgent
 from mcp import StdioServerParameters
 
 server_parameters = StdioServerParameters(
-    command="uv",
+    command="uvx",
     args=["--quiet", "pubmedmcp@0.1.3"],
     env={"UV_PYTHON": "3.12", **os.environ},
 )


### PR DESCRIPTION
I tried the example code. Didn't work. The official repo gave the right code which is `uvx` to execute the code.

https://github.com/grll/pubmedmcp