### PR TITLE
Refine tool-calling with the Agent and LLM

### DIFF
--- a/units/en/unit1/tools.mdx
+++ b/units/en/unit1/tools.mdx
@@ -47,7 +47,7 @@ LLMs, as we saw, can only receive text inputs and generate text outputs. They ha
 
 For example, if we provide a tool to check the weather at a location from the internet and then ask the LLM about the weather in Paris, the LLM will recognize that this is an opportunity to use the “weather” tool. Instead of retrieving the weather data itself, the LLM will generate text that represents a tool call, such as call weather_tool('Paris'). 
 
-The Agent (which is a piece of code or an algorithm) then reads this response, identifies that a tool call is required, executes the tool on the LLM’s behalf, and retrieves the actual weather data. 
+The **Agent** then reads this response, identifies that a tool call is required, executes the tool on the LLM’s behalf, and retrieves the actual weather data. 
 
 The Tool-calling steps are typically not shown to the user: the Agent appends them as a new message before passing the updated conversation to the LLM again. The LLM then processes this additional context and generates a natural-sounding response for the user. From the user’s perspective, it appears as if the LLM directly interacted with the tool, but in reality, it was the Agent that handled the entire execution process in the background.
 


### PR DESCRIPTION
Clarified the role of the Agent by explicitly defining it as a software component that acts as an intermediary between the LLM and external tools