### PR TITLE
fix link to redirect to correct unit

### DIFF
--- a/units/en/unit3/agentic-rag/tools.mdx
+++ b/units/en/unit3/agentic-rag/tools.mdx
@@ -81,7 +81,7 @@ The perfect gala would have fireworks over a clear sky, we need to make sure the
 Let's create a custom tool that can be used to call an external weather API and get the weather information for a given location.
 
 <Tip>
-For the sake of simplicity, we're using a dummy weather API for this example. If you want to use a real weather API, you could implement a weather tool that uses the OpenWeatherMap API, like in <a href="../unit1/tutorial">Unit 1</a>.
+For the sake of simplicity, we're using a dummy weather API for this example. If you want to use a real weather API, you could implement a weather tool that uses the OpenWeatherMap API, like in <a href="../../unit1/tutorial">Unit 1</a>.
 </Tip>
 
 <hfoptions id="agents-frameworks">


### PR DESCRIPTION
Just fixed the link that wasn't redirecting properly to Unit 1. It was including a "unit3" in the URL