### PR TITLE
Fix bug in unit3 invitees.mdx

### DIFF
--- a/units/en/unit3/agentic-rag/invitees.mdx
+++ b/units/en/unit3/agentic-rag/invitees.mdx
@@ -268,7 +268,7 @@ def extract_text(query: str) -> str:
     """Retrieves detailed information about gala guests based on their name or relation."""
     results = bm25_retriever.invoke(query)
     if results:
-        return "\n\n".join([doc.text for doc in results[:3]])
+        return "\n\n".join([doc.page_content for doc in results[:3]])
     else:
         return "No matching guest information found."
 
@@ -412,7 +412,7 @@ messages = [HumanMessage(content="Tell me about our guest named 'Lady Ada Lovela
 response = alfred.invoke({"messages": messages})
 
 print("🎩 Alfred's Response:")
-print(messages['messages'][-1].content)
+print(response['messages'][-1].content)
 ```
 
 Expected output:


### PR DESCRIPTION
Updated langgraph extract_text function to get document content from `page_content` instead of `text`.
Updated langgraph to print out `response` instead of input `messages` at the end.