### PR TITLE
fix: wrap agent prompt in fenced block for better copy-paste

### DIFF
--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -297,12 +297,7 @@ Question: the input question you must answer
 Thought: you should always think about one action to take. Only one action at a time in this format:  
 Action:
 
-    ```json
-    {
-      "action": "get_weather",
-      "action_input": {"location": {"type": "string", "value": "London"}}
-    }
-    ```
+$JSON_BLOB (inside markdown cell)
 
 Observation: the result of the action. This Observation is unique, complete, and the source of truth.  
 ... (this Thought/Action/Observation can repeat N times, you should take several steps when needed. The $JSON_BLOB must be formatted as markdown and only use a SINGLE action at a time.)

--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -273,9 +273,9 @@ final_output = client.text_generation(
 print(final_output)
 ```
 Here is the new prompt:
-````
+```text
 <|begin_of_text|><|start_header_id|>system<|end_header_id|>
-    Answer the following questions as best you can. You have access to the following tools:
+Answer the following questions as best you can. You have access to the following tools:
 
 get_weather: Get the current weather in a given location
 
@@ -286,40 +286,48 @@ The only values that should be in the "action" field are:
 get_weather: Get the current weather in a given location, args: {"location": {"type": "string"}}
 example use : 
 
-{{
+{
   "action": "get_weather",
   "action_input": {"location": "New York"}
-}}
+}
 
 ALWAYS use the following format:
 
-Question: the input question you must answer
-Thought: you should always think about one action to take. Only one action at a time in this format:
+Question: the input question you must answer  
+Thought: you should always think about one action to take. Only one action at a time in this format:  
 Action:
 
-$JSON_BLOB (inside markdown cell)
+    ```json
+    {
+      "action": "get_weather",
+      "action_input": {"location": {"type": "string", "value": "London"}}
+    }
+    ```
 
-Observation: the result of the action. This Observation is unique, complete, and the source of truth.
+Observation: the result of the action. This Observation is unique, complete, and the source of truth.  
 ... (this Thought/Action/Observation can repeat N times, you should take several steps when needed. The $JSON_BLOB must be formatted as markdown and only use a SINGLE action at a time.)
 
 You must always end your output with the following format:
 
-Thought: I now know the final answer
+Thought: I now know the final answer  
 Final Answer: the final answer to the original input question
 
-Now begin! Reminder to ALWAYS use the exact characters `Final Answer:` when you provide a definitive answer. 
+Now begin! Reminder to ALWAYS use the exact characters `Final Answer:` when you provide a definitive answer.
 <|eot_id|><|start_header_id|>user<|end_header_id|>
-What's the weather in London ?
+What's the weather in London?
 <|eot_id|><|start_header_id|>assistant<|end_header_id|>
-Thought: I will check the weather in London.
+Thought: I will check the weather in London.  
 Action:
-```
-{
-  "action": "get_weather",
-  "action_input": {"location": {"type": "string", "value": "London"}
-}
-```
-Observation:the weather in London is sunny with low temperatures. 
+
+    ```json
+    {
+      "action": "get_weather",
+      "action_input": {"location": {"type": "string", "value": "London"}}
+    }
+    ```
+
+Observation: The weather in London is sunny with low temperatures.
+
 ````
 
 Output:


### PR DESCRIPTION
This PR fixes an issue in dummy-agent-library.mdx where copying the agent prompt from the course page only returns the trailing line due to rendering quirks.
I’ve wrapped the entire system/user/assistant prompt inside a text-fenced code block, ensuring it's preserved fully and copyable without needing to go to GitHub directly.
