### PR TITLE
docs: Point Agentic RAG tutorial link to zh-CN version

### DIFF
--- a/units/zh-CN/unit2/smolagents/retrieval_agents.mdx
+++ b/units/zh-CN/unit2/smolagents/retrieval_agents.mdx
@@ -161,4 +161,4 @@ print(response)
 
 ## 资源
 
-- [Agentic RAG: 使用查询重构和自查询加速您的 RAG 系统！🚀](https://huggingface.co/learn/cookbook/agent_rag) - 使用 smolagents 开发智能驱动 RAG 系统的实践指南
+- [Agentic RAG: 使用查询重构和自查询加速您的 RAG 系统！🚀](https://huggingface.co/learn/cookbook/zh-CN/agent_rag) - 使用 smolagents 开发智能驱动 RAG 系统的实践指南


### PR DESCRIPTION
Change the from the default/English path to the explicit Chinese (`zh-CN`) path.

This ensures Chinese-speaking users are directed to the translated version.