### PR TITLE
fix: Add User-Agent header to resolve 403 Forbidden error

### DIFF
--- a/notebooks/unit2/smolagents/vision_agents.ipynb
+++ b/notebooks/unit2/smolagents/vision_agents.ipynb
@@ -38,12 +38,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Let's also login to the Hugging Face Hub to have access to the Inference API."
-      ],
       "metadata": {
         "id": "WJGFjRbZbL50"
-      }
+      },
+      "source": [
+        "Let's also login to the Hugging Face Hub to have access to the Inference API."
+      ]
     },
     {
       "cell_type": "code",
@@ -94,19 +94,22 @@
         "\n",
         "images = []\n",
         "for url in image_urls:\n",
-        "    response = requests.get(url)\n",
+        "    headers = {\n",
+        "        \"User-Agent\": \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36\" \n",
+        "    }\n",
+        "    response = requests.get(url,headers=headers)\n",
         "    image = Image.open(BytesIO(response.content)).convert(\"RGB\")\n",
         "    images.append(image)"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Now that we have the images, the agent will tell us wether the guests is actually a superhero (Wonder Woman) or a villian (The Joker)."
-      ],
       "metadata": {
         "id": "vUBQjETkbRU6"
-      }
+      },
+      "source": [
+        "Now that we have the images, the agent will tell us wether the guests is actually a superhero (Wonder Woman) or a villian (The Joker)."
+      ]
     },
     {
       "cell_type": "code",
@@ -499,12 +502,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "In this case, the output reveals that the person is impersonating someone else, so we can prevent The Joker from entering the party!"
-      ],
       "metadata": {
         "id": "NrV-yK5zbT9r"
-      }
+      },
+      "source": [
+        "In this case, the output reveals that the person is impersonating someone else, so we can prevent The Joker from entering the party!"
+      ]
     },
     {
       "cell_type": "markdown",

--- a/units/en/unit2/smolagents/vision_agents.mdx
+++ b/units/en/unit2/smolagents/vision_agents.mdx
@@ -42,7 +42,10 @@ image_urls = [
 
 images = []
 for url in image_urls:
-    response = requests.get(url)
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36" 
+    }
+    response = requests.get(url,headers=headers)
     image = Image.open(BytesIO(response.content)).convert("RGB")
     images.append(image)
 ```

--- a/units/zh-CN/unit2/smolagents/vision_agents.mdx
+++ b/units/zh-CN/unit2/smolagents/vision_agents.mdx
@@ -42,7 +42,10 @@ image_urls = [
 
 images = []
 for url in image_urls:
-    response = requests.get(url)
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36" 
+    }
+    response = requests.get(url,headers=headers)
     image = Image.open(BytesIO(response.content)).convert("RGB")
     images.append(image)
 ```


### PR DESCRIPTION
Added a `User-Agent` header to the `requests.get` call. Previous requests were being rejected by the server (e.g., Wikimedia) due to a missing User-Agent, resulting in an `HTTPError: 403 Client Error: Forbidden` error.

Adding this header is necessary to comply with the target server's User-Agent policy (e.g., Wikimedia's https://meta.wikimedia.org/wiki/User-Agent_policy) and ensure the request succeeds.