### PR TITLE
Add more info about starting Ollama and using LiteLLMModel

### DIFF
--- a/units/en/unit0/onboarding.mdx
+++ b/units/en/unit0/onboarding.mdx
@@ -67,8 +67,19 @@ You can download the image by clicking 👉 [here](https://huggingface.co/datase
 ``` bash
     ollama serve
 ``` 
+    If you run into the error "listen tcp 127.0.0.1:11434: bind: address already in use", you can use command `sudo lsof -i :11434` to identify the process
+    ID (PID) that is currently using this port. If the process is `ollama`, it is likely that the installation script above has started ollama
+    service, so you can skip this command to start Ollama.
+
 4. **Use `LiteLLMModel` Instead of `HfApiModel`**
+
+   To use `LiteLLMModel` module in `smolagents`, you may run `pip` command to install the module.
+
 ``` bash
+    pip install smolagents[litellm]
+```
+
+``` python
     from smolagents import LiteLLMModel
 
     model = LiteLLMModel(


### PR DESCRIPTION
1. Add one paragraph about the error "listen tcp 127.0.0.1:11434: bind: address already in use" for starting Ollama.
2. Add `pip` command to install `smolagents[litellm]`.