### PR TITLE
Fix hallucinated bullet-point about persisting data

### DIFF
--- a/units/en/unit2/smolagents/retrieval_agents.mdx
+++ b/units/en/unit2/smolagents/retrieval_agents.mdx
@@ -56,7 +56,8 @@ The agent follows this process:
 1. **Analyzes the Request:** Alfred’s agent identifies the key elements of the query—luxury superhero-themed party planning, with focus on decor, entertainment, and catering.
 2. **Performs Retrieval:**  The agent leverages DuckDuckGo to search for the most relevant and up-to-date information, ensuring it aligns with Alfred’s refined preferences for a luxurious event.
 3. **Synthesizes Information:** After gathering the results, the agent processes them into a cohesive, actionable plan for Alfred, covering all aspects of the party.
-4. **Stores for Future Reference:** The agent stores the retrieved information for easy access when planning future events, optimizing efficiency in subsequent tasks.
+
+These agents can also be extended to store the retrieved information for easy access when planning future events, optimizing efficiency in subsequent tasks.
 
 ## Custom Knowledge Base Tool
 


### PR DESCRIPTION
In practice, agents will store their results, but from what I can see in this example, it is not yet included.

I clarified the text by saying it could be extended.