### PR TITLE
Use `Llama-3.3-70B-Instruct` model instead

### DIFF
--- a/notebooks/unit1/dummy_agent_library.ipynb
+++ b/notebooks/unit1/dummy_agent_library.ipynb
@@ -44,7 +44,7 @@
     "- If you are running this notebook on Google Colab, you can set it up in the \"settings\" tab under \"secrets\". Make sure to call it \"HF_TOKEN\" and restart the session to load the environment variable (Runtime -> Restart session).\n",
     "- If you are running this notebook locally, you can set it up as an [environment variable](https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables). Make sure you restart the kernel after installing or updating huggingface_hub. You can update huggingface_hub by modifying the above `!pip install -q huggingface_hub -U`\n",
     "\n",
-    "You also need to request access to [the Meta Llama models](https://huggingface.co/meta-llama), select [Llama-3.2-3B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct) if you haven't done it click on Expand to review and access and fill the form. Approval usually takes up to an hour."
+    "You also need to request access to [the Meta Llama models](https://huggingface.co/meta-llama), select [Llama-3.3-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct) if you haven't done it click on Expand to review and access and fill the form. Approval usually takes up to an hour."
    ]
   },
   {
@@ -64,8 +64,8 @@
     "\n",
     "\n",
     "\n",
-    "client = InferenceClient(\"meta-llama/Llama-3.2-3B-Instruct\")\n",
-    "# if the outputs for next cells are wrong, the free model may be overloaded. You can also use this public endpoint that contains Llama-3.2-3B-Instruct\n",
+    "client = InferenceClient(\"meta-llama/Llama-3.3-70B-Instruct\")\n",
+    "# if the outputs for next cells are wrong, the free model may be overloaded. You can also use this public endpoint that contains Llama-3.3-70B-Instruct\n",
     "#client = InferenceClient(\"https://jc26mwg228mkj8dw.us-east-1.aws.endpoints.huggingface.cloud\")"
    ]
   },
@@ -118,7 +118,7 @@
     "id": "T9-6h-eVAWrR"
    },
    "source": [
-    "If we now add the special tokens related to the <a href=\"https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct\">Llama-3.2-3B-Instruct model</a> that we're using, the behavior changes and it now produces the expected EOS."
+    "If we now add the special tokens related to the <a href=\"https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct\">Llama-3.3-70B-Instruct model</a> that we're using, the behavior changes and it now produces the expected EOS."
    ]
   },
   {
@@ -317,7 +317,7 @@
     "    {\"role\": \"user\", \"content\": \"What's the weather in London ?\"},\n",
     "]\n",
     "from transformers import AutoTokenizer\n",
-    "tokenizer = AutoTokenizer.from_pretrained(\"meta-llama/Llama-3.2-3B-Instruct\")\n",
+    "tokenizer = AutoTokenizer.from_pretrained(\"meta-llama/Llama-3.3-70B-Instruct\")\n",
     "\n",
     "tokenizer.apply_chat_template(messages, tokenize=False,add_generation_prompt=True)\n",
     "```"


### PR DESCRIPTION
The `Llama-3.2-3B-Instruct` is not available for `provider=hf-inference`  ([link](https://huggingface.co/models?inference_provider=hf-inference&sort=trending))

The error we get when running notebook now:
```
HfHubHTTPError: 404 Client Error: Not Found for url: https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.2-3B-Instruct
```

To make this notebook work,  we could change the model to `Llama-3.3-70B-Instruct`, which is listed for the provider.