### PR TITLE
[Fix]: Unit 1 `dummy_agent_library.ipynb` - Model Access Failure

### DIFF
--- a/notebooks/unit1/dummy_agent_library.ipynb
+++ b/notebooks/unit1/dummy_agent_library.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "This notebook is part of the <a href=\"https://www.hf.co/learn/agents-course\">Hugging Face Agents Course</a>, a free Course from beginner to expert, where you learn to build Agents.\n",
     "\n",
-    "<img src=\"https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/communication/share.png\" alt=\"Agent Course\"/>"
+    "<img src=\"https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/communication/share.png\" alt=\"Agent Course\"/>\n"
    ]
   },
   {
@@ -40,11 +40,12 @@
     "\n",
     "In the Hugging Face ecosystem, there is a convenient feature called Serverless API that allows you to easily run inference on many models. There's no installation or deployment required.\n",
     "\n",
-    "To run this notebook, **you need a Hugging Face token** that you can get from https://hf.co/settings/tokens. A \"Read\" token type is sufficient. \n",
+    "To run this notebook, **you need a Hugging Face token** that you can get from https://hf.co/settings/tokens. A \"Read\" token type is sufficient.\n",
+    "\n",
     "- If you are running this notebook on Google Colab, you can set it up in the \"settings\" tab under \"secrets\". Make sure to call it \"HF_TOKEN\" and restart the session to load the environment variable (Runtime -> Restart session).\n",
     "- If you are running this notebook locally, you can set it up as an [environment variable](https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables). Make sure you restart the kernel after installing or updating huggingface_hub. You can update huggingface_hub by modifying the above `!pip install -q huggingface_hub -U`\n",
     "\n",
-    "You also need to request access to [the Meta Llama models](https://huggingface.co/meta-llama), select [Llama-3.2-3B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct) if you haven't done it click on Expand to review and access and fill the form. Approval usually takes up to an hour."
+    "You also need to request access to [the Meta Llama models](https://huggingface.co/meta-llama), select [Llama-3.2-3B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct) if you haven't done it click on Expand to review and access and fill the form. Approval usually takes up to an hour.\n"
    ]
   },
   {
@@ -64,14 +65,14 @@
     "\n",
     "\n",
     "\n",
-    "client = InferenceClient(\"meta-llama/Llama-3.2-3B-Instruct\")\n",
+    "client = InferenceClient(\"meta-llama/Llama-3.2-3B-Instruct\", provider=\"hf-inference\")\n",
     "# if the outputs for next cells are wrong, the free model may be overloaded. You can also use this public endpoint that contains Llama-3.2-3B-Instruct\n",
     "#client = InferenceClient(\"https://jc26mwg228mkj8dw.us-east-1.aws.endpoints.huggingface.cloud\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 14,
    "id": "c918666c-48ed-4d6d-ab91-c6ec3892d858",
    "metadata": {
     "colab": {
@@ -86,7 +87,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris.\n"
+      " paris\n",
+      "The capital of France is Paris. Paris, the City of Light, is known for its stunning architecture, art museums, fashion, and romantic atmosphere. It's a must-visit destination for anyone interested in history, culture, and beauty. The Eiffel Tower, the Louvre Museum, and Notre-Dame Cathedral are just a few of the many iconic landmarks that make Paris a unique and unforgettable experience. Whether you're interested in exploring the city's charming neighborhoods, enjoying the local cuisine\n"
      ]
     }
    ],
@@ -108,7 +110,7 @@
     "id": "w2C4arhyKAEk"
    },
    "source": [
-    "As seen in the LLM section, if we just do decoding, **the model will only stop when it predicts an EOS token**, and this does not happen here because this is a conversational (chat) model and **we didn't apply the chat template it expects**."
+    "As seen in the LLM section, if we just do decoding, **the model will only stop when it predicts an EOS token**, and this does not happen here because this is a conversational (chat) model and **we didn't apply the chat template it expects**.\n"
    ]
   },
   {
@@ -118,7 +120,7 @@
     "id": "T9-6h-eVAWrR"
    },
    "source": [
-    "If we now add the special tokens related to the <a href=\"https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct\">Llama-3.2-3B-Instruct model</a> that we're using, the behavior changes and it now produces the expected EOS."
+    "If we now add the special tokens related to the <a href=\"https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct\">Llama-3.2-3B-Instruct model</a> that we're using, the behavior changes and it now produces the expected EOS.\n"
    ]
   },
   {
@@ -164,7 +166,7 @@
     "id": "1uKapsiZAbH5"
    },
    "source": [
-    "Using the \"chat\" method is a much more convenient and reliable way to apply chat templates:"
+    "Using the \"chat\" method is a much more convenient and reliable way to apply chat templates:\n"
    ]
   },
   {
@@ -224,7 +226,7 @@
     "This system prompt is a bit more complex than the one we saw earlier, but it already contains:\n",
     "\n",
     "1. **Information about the tools**\n",
-    "2. **Cycle instructions** (Thought → Action → Observation)"
+    "2. **Cycle instructions** (Thought → Action → Observation)\n"
    ]
   },
   {
@@ -281,7 +283,7 @@
     "id": "UoanEUqQAxzE"
    },
    "source": [
-    "Since we are running the \"text_generation\" method, we need to add the right special tokens."
+    "Since we are running the \"text_generation\" method, we need to add the right special tokens.\n"
    ]
   },
   {
@@ -311,6 +313,7 @@
    },
    "source": [
     "This is equivalent to the following code that happens inside the chat method :\n",
+    "\n",
     "```\n",
     "messages=[\n",
     "    {\"role\": \"system\", \"content\": SYSTEM_PROMPT},\n",
@@ -320,7 +323,7 @@
     "tokenizer = AutoTokenizer.from_pretrained(\"meta-llama/Llama-3.2-3B-Instruct\")\n",
     "\n",
     "tokenizer.apply_chat_template(messages, tokenize=False,add_generation_prompt=True)\n",
-    "```"
+    "```\n"
    ]
   },
   {
@@ -330,7 +333,7 @@
     "id": "4jCyx4HZCIA8"
    },
    "source": [
-    "The prompt is now:"
+    "The prompt is now:\n"
    ]
   },
   {
@@ -401,7 +404,7 @@
     "id": "S6fosEhBCObv"
    },
    "source": [
-    "Let’s decode!"
+    "Let’s decode!\n"
    ]
   },
   {
@@ -453,9 +456,9 @@
     "id": "9NbUFRDECQ9N"
    },
    "source": [
-    "Do you see the problem? \n",
+    "Do you see the problem?\n",
     "\n",
-    "The **answer was hallucinated by the model**. We need to stop to actually execute the function!"
+    "The **answer was hallucinated by the model**. We need to stop to actually execute the function!\n"
    ]
   },
   {
@@ -508,7 +511,7 @@
    "source": [
     "Much Better!\n",
     "\n",
-    "Let's now create a **dummy get weather function**. In a real situation you could call an API."
+    "Let's now create a **dummy get weather function**. In a real situation you could call an API.\n"
    ]
   },
   {
@@ -554,7 +557,7 @@
     "id": "IHL3bqhYLGQ6"
    },
    "source": [
-    "Let's concatenate the base prompt, the completion until function execution and the result of the function as an Observation and resume the generation."
+    "Let's concatenate the base prompt, the completion until function execution and the result of the function as an Observation and resume the generation.\n"
    ]
   },
   {
@@ -638,7 +641,7 @@
     "id": "Cc7Jb8o3Lc_4"
    },
    "source": [
-    "Here is the new prompt:"
+    "Here is the new prompt:\n"
    ]
   },
   {
@@ -677,7 +680,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "hf",
    "language": "python",
    "name": "python3"
   },
@@ -691,7 +694,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pull request addresses a critical bug in Unit 1 (`dummy_agent_library.ipynb`) that prevents students from accessing the `meta-llama/Llama-3.2-3B-Instruct` model. The original code resulted in a "model not supported" or "404 Not Found" error, and using public endpoints yielded "endpoint paused" error.

The solution adds the `provider="hf-inference"` argument to the `InferenceClient`, explicitly specifying the inference provider. This resolves the issue by correctly directing the request, allowing students to proceed with the course without encountering these blocking errors. This seemingly small change addresses a common point of failure for beginners.
