### PR TITLE
Fix: For meta-llama/Llama-3.3-70B-Instruct fix link and outputs

### DIFF
--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -163,7 +163,7 @@ Answer the following questions as best you can. You have access to the following
 get_weather: Get the current weather in a given location
 
 The way you use the tools is by specifying a json blob.
-Specifically, this json should have a `action` key (with the name of the tool to use) and a `action_input` key (with the input to the tool going here).
+Specifically, this json should have an `action` key (with the name of the tool to use) and a `action_input` key (with the input to the tool going here).
 
 The only values that should be in the "action" field are:
 get_weather: Get the current weather in a given location, args: {"location": {"type": "string"}}
@@ -310,21 +310,21 @@ You must always end your output with the following format:
 Thought: I now know the final answer
 Final Answer: the final answer to the original input question
 
-Now begin! Reminder to ALWAYS use the exact characters `Final Answer:` when you provide a definitive answer. 
+Now begin! Reminder to ALWAYS use the exact characters `Final Answer:` when you provide a definitive answer.
 <|eot_id|><|start_header_id|>user<|end_header_id|>
-What's the weather in London ?
+What's the weather in London?
 <|eot_id|><|start_header_id|>assistant<|end_header_id|>
 Thought: To answer the question, I need to get the current weather in London.
 Action:
 
     ```json
     {
-    "action": "get_weather",
-    "action_input": {"location": "London"}
+      "action": "get_weather",
+      "action_input": {"location": "London"}
     }
     ```
 
-Observation:the weather in London is sunny with low temperatures. 
+Observation: The weather in London is sunny with low temperatures.
 
 ````
 

--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -46,7 +46,7 @@ print(output)
 ```
 output:
 ```
-Paris. The capital of France is Paris. Paris, the City of Light, is known for its stunning architecture, art museums, fashion, and romantic atmosphere. It's a must-visit destination for anyone interested in history, culture, and beauty. The Eiffel Tower, the Louvre Museum, and Notre-Dame Cathedral are just a few of the many iconic landmarks that make Paris a unique and unforgettable experience. Whether you're interested in exploring the city's charming neighborhoods, enjoying the local cuisine
+Paris. The capital of France is Paris. Paris, the City of Light, is known for its stunning architecture, art museums, fashion, and romantic atmosphere. It's a must-visit destination for anyone interested in history, culture, and beauty. The Eiffel Tower, the Louvre Museum, and Notre-Dame Cathedral are just a few of the many iconic landmarks that make Paris a unique and unforgettable experience. Whether you're interested in exploring the city's charming neighborhoods, enjoying the local cuisine.
 ```
 As seen in the LLM section, if we just do decoding, **the model will only stop when it predicts an EOS token**, and this does not happen here because this is a conversational (chat) model and **we didn't apply the chat template it expects**.
 
@@ -150,7 +150,7 @@ messages=[
     {"role": "user", "content": "What's the weather in London ?"},
     ]
 from transformers import AutoTokenizer
-tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.2-3B-Instruct")
+tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.3-70B-Instruct")
 
 tokenizer.apply_chat_template(messages, tokenize=False,add_generation_prompt=True)
 ```

--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -31,7 +31,7 @@ from huggingface_hub import InferenceClient
 ## You need a token from https://hf.co/settings/tokens, ensure that you select 'read' as the token type. If you run this on Google Colab, you can set it up in the "settings" tab under "secrets". Make sure to call it "HF_TOKEN"
 os.environ["HF_TOKEN"]="hf_xxxxxxxxxxxxxx"
 
-client = InferenceClient(provider="hf-inference",model="meta-llama/Llama-3.3-70B-Instruct")
+client = InferenceClient("meta-llama/Llama-3.3-70B-Instruct")
 # if the outputs for next cells are wrong, the free model may be overloaded. You can also use this public endpoint that contains Llama-3.2-3B-Instruct
 # client = InferenceClient("https://jc26mwg228mkj8dw.us-east-1.aws.endpoints.huggingface.cloud")
 ```

--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -46,7 +46,7 @@ print(output)
 ```
 output:
 ```
-paris. The capital of France is Paris. Paris, the City of Light, is known for its stunning architecture, art museums, fashion, and romantic atmosphere. It's a must-visit destination for anyone interested in history, culture, and beauty. The Eiffel Tower, the Louvre Museum, and Notre-Dame Cathedral are just a few of the many iconic landmarks that make Paris a unique and unforgettable experience. Whether you're interested in exploring the city's charming neighborhoods, enjoying the local cuisine
+Paris. The capital of France is Paris. Paris, the City of Light, is known for its stunning architecture, art museums, fashion, and romantic atmosphere. It's a must-visit destination for anyone interested in history, culture, and beauty. The Eiffel Tower, the Louvre Museum, and Notre-Dame Cathedral are just a few of the many iconic landmarks that make Paris a unique and unforgettable experience. Whether you're interested in exploring the city's charming neighborhoods, enjoying the local cuisine
 ```
 As seen in the LLM section, if we just do decoding, **the model will only stop when it predicts an EOS token**, and this does not happen here because this is a conversational (chat) model and **we didn't apply the chat template it expects**.
 
@@ -168,7 +168,7 @@ Specifically, this json should have a `action` key (with the name of the tool to
 The only values that should be in the "action" field are:
 get_weather: Get the current weather in a given location, args: {"location": {"type": "string"}}
 example use :
-```
+
 {{
   "action": "get_weather",
   "action_input": {"location": "New York"}
@@ -179,9 +179,9 @@ ALWAYS use the following format:
 Question: the input question you must answer
 Thought: you should always think about one action to take. Only one action at a time in this format:
 Action:
-```
-$JSON_BLOB
-```
+
+$JSON_BLOB (inside markdown cell)
+
 Observation: the result of the action. This Observation is unique, complete, and the source of truth.
 ... (this Thought/Action/Observation can repeat N times, you should take several steps when needed. The $JSON_BLOB must be formatted as markdown and only use a SINGLE action at a time.)
 
@@ -209,18 +209,15 @@ output:
 
 ````
 Thought: To answer the question, I need to get the current weather in London.
-
 Action:
-```json
+```
 {
   "action": "get_weather",
   "action_input": {"location": "London"}
 }
 ```
-
 Observation: The current weather in London is partly cloudy with a temperature of 12°C.
-
-Thought: I now know the final answer
+Thought: I now know the final answer.
 Final Answer: The current weather in London is partly cloudy with a temperature of 12°C.
 ````
 
@@ -242,9 +239,8 @@ output:
 
 ````
 Thought: To answer the question, I need to get the current weather in London.
-
 Action:
-```json
+```
 {
   "action": "get_weather",
   "action_input": {"location": "London"}
@@ -292,20 +288,20 @@ Specifically, this json should have a `action` key (with the name of the tool to
 The only values that should be in the "action" field are:
 get_weather: Get the current weather in a given location, args: {"location": {"type": "string"}}
 example use :
-```
-{{
+
+{
   "action": "get_weather",
   "action_input": {"location": "New York"}
-}}
+}
 
 ALWAYS use the following format:
 
 Question: the input question you must answer
 Thought: you should always think about one action to take. Only one action at a time in this format:
 Action:
-```
-$JSON_BLOB
-```
+
+$JSON_BLOB (inside markdown cell)
+
 Observation: the result of the action. This Observation is unique, complete, and the source of truth.
 ... (this Thought/Action/Observation can repeat N times, you should take several steps when needed. The $JSON_BLOB must be formatted as markdown and only use a SINGLE action at a time.)
 
@@ -319,14 +315,14 @@ Now begin! Reminder to ALWAYS use the exact characters `Final Answer:` when you 
 What's the weather in London ?
 <|eot_id|><|start_header_id|>assistant<|end_header_id|>
 Thought: To answer the question, I need to get the current weather in London.
-
 Action:
-```json
-{
-  "action": "get_weather",
-  "action_input": {"location": "London"}
-}
-```
+
+    ```json
+    {
+    "action": "get_weather",
+    "action_input": {"location": "London"}
+    }
+    ```
 
 Observation:the weather in London is sunny with low temperatures. 
 

--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -31,7 +31,7 @@ from huggingface_hub import InferenceClient
 ## You need a token from https://hf.co/settings/tokens, ensure that you select 'read' as the token type. If you run this on Google Colab, you can set it up in the "settings" tab under "secrets". Make sure to call it "HF_TOKEN"
 os.environ["HF_TOKEN"]="hf_xxxxxxxxxxxxxx"
 
-client = InferenceClient("meta-llama/Llama-3.2-3B-Instruct")
+client = InferenceClient(provider="hf-inference",model="meta-llama/Llama-3.3-70B-Instruct")
 # if the outputs for next cells are wrong, the free model may be overloaded. You can also use this public endpoint that contains Llama-3.2-3B-Instruct
 # client = InferenceClient("https://jc26mwg228mkj8dw.us-east-1.aws.endpoints.huggingface.cloud")
 ```
@@ -46,11 +46,11 @@ print(output)
 ```
 output:
 ```
-Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris.
+paris. The capital of France is Paris. Paris, the City of Light, is known for its stunning architecture, art museums, fashion, and romantic atmosphere. It's a must-visit destination for anyone interested in history, culture, and beauty. The Eiffel Tower, the Louvre Museum, and Notre-Dame Cathedral are just a few of the many iconic landmarks that make Paris a unique and unforgettable experience. Whether you're interested in exploring the city's charming neighborhoods, enjoying the local cuisine
 ```
 As seen in the LLM section, if we just do decoding, **the model will only stop when it predicts an EOS token**, and this does not happen here because this is a conversational (chat) model and **we didn't apply the chat template it expects**.
 
-If we now add the special tokens related to the <a href="https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct">Llama-3.2-3B-Instruct model</a> that we're using, the behavior changes and it now produces the expected EOS.
+If we now add the special tokens related to the <a href="https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct">Llama-3.3-70B-Instruct model</a> that we're using, the behavior changes and it now produces the expected EOS.
 
 ```python
 prompt="""<|begin_of_text|><|start_header_id|>user<|end_header_id|>
@@ -80,7 +80,7 @@ print(output.choices[0].message.content)
 ```
 output:
 ```
-Paris.
+The capital of France is Paris.
 ```
 The chat method is the RECOMMENDED method to use in order to ensure a smooth transition between models, but since this notebook is only educational, we will keep using the "text_generation" method to understand the details.
 
@@ -163,12 +163,12 @@ Answer the following questions as best you can. You have access to the following
 get_weather: Get the current weather in a given location
 
 The way you use the tools is by specifying a json blob.
-Specifically, this json should have an `action` key (with the name of the tool to use) and a `action_input` key (with the input to the tool going here).
+Specifically, this json should have a `action` key (with the name of the tool to use) and a `action_input` key (with the input to the tool going here).
 
 The only values that should be in the "action" field are:
 get_weather: Get the current weather in a given location, args: {"location": {"type": "string"}}
-example use : 
-
+example use :
+```
 {{
   "action": "get_weather",
   "action_input": {"location": "New York"}
@@ -179,9 +179,9 @@ ALWAYS use the following format:
 Question: the input question you must answer
 Thought: you should always think about one action to take. Only one action at a time in this format:
 Action:
-
-$JSON_BLOB (inside markdown cell)
-
+```
+$JSON_BLOB
+```
 Observation: the result of the action. This Observation is unique, complete, and the source of truth.
 ... (this Thought/Action/Observation can repeat N times, you should take several steps when needed. The $JSON_BLOB must be formatted as markdown and only use a SINGLE action at a time.)
 
@@ -208,15 +208,20 @@ print(output)
 output:
 
 ````
-Thought: I will check the weather in London.
+Thought: To answer the question, I need to get the current weather in London.
+
 Action:
-```
+```json
 {
   "action": "get_weather",
   "action_input": {"location": "London"}
 }
 ```
-Observation: The current weather in London is mostly cloudy with a high of 12°C and a low of 8°C.
+
+Observation: The current weather in London is partly cloudy with a temperature of 12°C.
+
+Thought: I now know the final answer
+Final Answer: The current weather in London is partly cloudy with a temperature of 12°C.
 ````
 
 Do you see the issue?
@@ -236,9 +241,10 @@ print(output)
 output:
 
 ````
-Thought: I will check the weather in London.
+Thought: To answer the question, I need to get the current weather in London.
+
 Action:
-```
+```json
 {
   "action": "get_weather",
   "action_input": {"location": "London"}
@@ -285,44 +291,44 @@ Specifically, this json should have a `action` key (with the name of the tool to
 
 The only values that should be in the "action" field are:
 get_weather: Get the current weather in a given location, args: {"location": {"type": "string"}}
-example use : 
-
-{
+example use :
+```
+{{
   "action": "get_weather",
   "action_input": {"location": "New York"}
-}
+}}
 
 ALWAYS use the following format:
 
-Question: the input question you must answer  
-Thought: you should always think about one action to take. Only one action at a time in this format:  
+Question: the input question you must answer
+Thought: you should always think about one action to take. Only one action at a time in this format:
 Action:
-
-$JSON_BLOB (inside markdown cell)
-
-Observation: the result of the action. This Observation is unique, complete, and the source of truth.  
+```
+$JSON_BLOB
+```
+Observation: the result of the action. This Observation is unique, complete, and the source of truth.
 ... (this Thought/Action/Observation can repeat N times, you should take several steps when needed. The $JSON_BLOB must be formatted as markdown and only use a SINGLE action at a time.)
 
 You must always end your output with the following format:
 
-Thought: I now know the final answer  
+Thought: I now know the final answer
 Final Answer: the final answer to the original input question
 
-Now begin! Reminder to ALWAYS use the exact characters `Final Answer:` when you provide a definitive answer.
+Now begin! Reminder to ALWAYS use the exact characters `Final Answer:` when you provide a definitive answer. 
 <|eot_id|><|start_header_id|>user<|end_header_id|>
-What's the weather in London?
+What's the weather in London ?
 <|eot_id|><|start_header_id|>assistant<|end_header_id|>
-Thought: I will check the weather in London.  
+Thought: To answer the question, I need to get the current weather in London.
+
 Action:
+```json
+{
+  "action": "get_weather",
+  "action_input": {"location": "London"}
+}
+```
 
-    ```json
-    {
-      "action": "get_weather",
-      "action_input": {"location": {"type": "string", "value": "London"}}
-    }
-    ```
-
-Observation: The weather in London is sunny with low temperatures.
+Observation:the weather in London is sunny with low temperatures. 
 
 ````
 

--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -320,7 +320,7 @@ Action:
     ```json
     {
       "action": "get_weather",
-      "action_input": {"location": "London"}
+      "action_input": {"location": {"type": "string", "value": "London"}}
     }
     ```
 


### PR DESCRIPTION
The Llama-3.2-3B-Instruct is not available for provider=hf-inference [https://huggingface.co/models?inference_provider=hf-inference&sort=trending](url)

someone already raised PR for dummy_agent_library.ipynb so I worked on dummy-agent-library.mdx make changes like text  code, links, changed every output   for meta-llama/Llama-3.3-70B-Instruct

One of changes:
![Screenshot 2025-05-11 030105](https://github.com/user-attachments/assets/2ec3c1b6-0e7d-4da3-8ccb-a45679bb78b8)
![Screenshot 2025-05-11 030050](https://github.com/user-attachments/assets/960fc7d1-7e50-4519-874a-e6d5e23b4775)

