### PR TITLE
Add quotes to pip install optional package

### DIFF
--- a/units/en/unit0/onboarding.mdx
+++ b/units/en/unit0/onboarding.mdx
@@ -76,7 +76,7 @@ You can download the image by clicking 👉 [here](https://huggingface.co/datase
    To use `LiteLLMModel` module in `smolagents`, you may run `pip` command to install the module.
 
 ``` bash
-    pip install smolagents[litellm]
+    pip install 'smolagents[litellm]'
 ```
 
 ``` python


### PR DESCRIPTION
Prevent issues with installing the python optional package.

error without apostrophes on Mac and ZSH
```sh
pip install smolagents[litellm]
zsh: no matches found: smolagents[litellm]
```