### PR TITLE
Updated notebooks refs to point to HF Org

### DIFF
--- a/units/en/bonus-unit2/monitoring-and-evaluating-agents-notebook.mdx
+++ b/units/en/bonus-unit2/monitoring-and-evaluating-agents-notebook.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/bonus-unit2/monitoring-and-evaluating-agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/bonus-unit2/monitoring-and-evaluating-agents.ipynb"},
 ]} />
 
 # Bonus Unit 2: Observability and Evaluation of Agents

--- a/units/en/bonus-unit2/what-is-agent-observability-and-evaluation.mdx
+++ b/units/en/bonus-unit2/what-is-agent-observability-and-evaluation.mdx
@@ -52,7 +52,7 @@ Here are some of the most common metrics that observability tools monitor:
 
 **Automated Evaluation Metrics:** You can also set up automated evals. For instance, you can use an LLM to score the output of the agent e.g. if it is helpful, accurate, or not. There are also several open source libraries that help you to score different aspects of the agent. E.g. [RAGAS](https://docs.ragas.io/) for RAG agents or [LLM Guard](https://llm-guard.com/) to detect harmful language or prompt injection. 
 
-In practice, a combination of these metrics gives the best coverage of an AI agent’s health. In this chapters [example notebook](https://huggingface.co/learn/agents-course/en/bonus-unit2/monitoring-and-evaluating-agents-notebook), we'll show you how these metrics looks in real examples but first, we'll learn how a typical evaluation workflow looks like.
+In practice, a combination of these metrics gives the best coverage of an AI agent’s health. In this chapters [example notebook](https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/bonus-unit2/monitoring-and-evaluating-agents.ipynb), we'll show you how these metrics looks in real examples but first, we'll learn how a typical evaluation workflow looks like.
 
 ## 👍 Evaluating AI Agents
 

--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -18,7 +18,7 @@ To keep things simple we will use a simple Python function as a Tool and Agent.
 
 We will use built-in Python packages like `datetime` and `os` so that you can try it out in any environment.
 
-You can follow the process [in this notebook](https://huggingface.co/agents-course/notebooks/blob/main/dummy_agent_library.ipynb) and **run the code yourself**.
+You can follow the process [in this notebook](https://huggingface.co/agents-course/notebooks/blob/main/unit1/dummy_agent_library.ipynb) and **run the code yourself**.
 
 ## Serverless API
 

--- a/units/en/unit1/what-are-llms.mdx
+++ b/units/en/unit1/what-are-llms.mdx
@@ -216,7 +216,7 @@ If you'd like to dive even deeper into the fascinating world of language models 
 
 Now that we understand how LLMs work, it's time to see **how LLMs structure their generations in a conversational context**.
 
-To run <a href="https://huggingface.co/agents-course/notebooks/blob/main/dummy_agent_library.ipynb" target="_blank">this notebook</a>, **you need a Hugging Face token** that you can get from <a href="https://hf.co/settings/tokens" target="_blank">https://hf.co/settings/tokens</a>.
+To run <a href="https://huggingface.co/agents-course/notebooks/blob/main/unit1/dummy_agent_library.ipynb" target="_blank">this notebook</a>, **you need a Hugging Face token** that you can get from <a href="https://hf.co/settings/tokens" target="_blank">https://hf.co/settings/tokens</a>.
 
 For more information on how to run Jupyter Notebooks, checkout <a href="https://huggingface.co/docs/hub/notebooks">Jupyter Notebooks on the Hugging Face Hub</a>.
 

--- a/units/en/unit2/smolagents/code_agents.mdx
+++ b/units/en/unit2/smolagents/code_agents.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/code_agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/code_agents.ipynb"},
 ]} />
 
 # Building Agents That Use Code

--- a/units/en/unit2/smolagents/multi_agent_systems.mdx
+++ b/units/en/unit2/smolagents/multi_agent_systems.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/multiagent_notebook.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/multiagent_notebook.ipynb"},
 ]} />
 
 # Multi-Agent Systems

--- a/units/en/unit2/smolagents/retrieval_agents.mdx
+++ b/units/en/unit2/smolagents/retrieval_agents.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/retrieval_agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/retrieval_agents.ipynb"},
 ]} />
 
 # Building Agentic RAG Systems

--- a/units/en/unit2/smolagents/tool_calling_agents.mdx
+++ b/units/en/unit2/smolagents/tool_calling_agents.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/tool_calling_agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/tool_calling_agents.ipynb"},
 ]} />
 
 # Writing actions as code snippets or JSON blobs

--- a/units/en/unit2/smolagents/tools.mdx
+++ b/units/en/unit2/smolagents/tools.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/tools.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/tools.ipynb"},
 ]} />
 
 # Tools

--- a/units/en/unit2/smolagents/vision_agents.mdx
+++ b/units/en/unit2/smolagents/vision_agents.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/vision_agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/vision_agents.ipynb"},
 ]} />
 
 # Vision Agents with smolagents

--- a/units/es/bonus-unit2/monitoring-and-evaluating-agents-notebook.mdx
+++ b/units/es/bonus-unit2/monitoring-and-evaluating-agents-notebook.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/bonus-unit2/monitoring-and-evaluating-agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/bonus-unit2/monitoring-and-evaluating-agents.ipynb"},
 ]} />
 
 # Unidad Extra 2: Observabilidad y Evaluación de Agentes

--- a/units/es/bonus-unit2/what-is-agent-observability-and-evaluation.mdx
+++ b/units/es/bonus-unit2/what-is-agent-observability-and-evaluation.mdx
@@ -52,7 +52,7 @@ Aquí hay algunas de las métricas más comunes que las herramientas de observab
 
 **Métricas de Evaluación Automatizadas:** También puedes configurar evaluaciones automatizadas. Por ejemplo, puedes usar un LLM para puntuar la salida del agente, por ejemplo, si es útil, precisa o no. También hay varias bibliotecas de código abierto que te ayudan a puntuar diferentes aspectos del agente. Por ejemplo, [RAGAS](https://docs.ragas.io/) para agentes RAG o [LLM Guard](https://llm-guard.com/) para detectar lenguaje dañino o inyección de prompts.
 
-En la práctica, una combinación de estas métricas proporciona la mejor cobertura de la salud de un agente de IA. En el [notebook de ejemplo](notebooks/bonus-unit2/monitoring-and-evaluating-agents.ipynb) de este capítulo, te mostraremos cómo se ven estas métricas en ejemplos reales, pero primero, aprenderemos cómo es un flujo de trabajo de evaluación típico.
+En la práctica, una combinación de estas métricas proporciona la mejor cobertura de la salud de un agente de IA. En el [notebook de ejemplo](https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/bonus-unit2/monitoring-and-evaluating-agents.ipynb) de este capítulo, te mostraremos cómo se ven estas métricas en ejemplos reales, pero primero, aprenderemos cómo es un flujo de trabajo de evaluación típico.
 
 ## 👍 Evaluando Agentes de IA
 

--- a/units/es/unit1/dummy-agent-library.mdx
+++ b/units/es/unit1/dummy-agent-library.mdx
@@ -18,7 +18,7 @@ Para mantener las cosas simples, utilizaremos una función simple de Python como
 
 Utilizaremos paquetes integrados de Python como `datetime` y `os` para que puedas probarlo en cualquier entorno.
 
-Puedes seguir el proceso [en este notebook](https://huggingface.co/agents-course/notebooks/blob/main/dummy_agent_library.ipynb) y **ejecutar el código tú mismo**.
+Puedes seguir el proceso [en este notebook](https://huggingface.co/agents-course/notebooks/blob/main/unit1/dummy_agent_library.ipynb) y **ejecutar el código tú mismo**.
 
 ## API Serverless
 
@@ -31,7 +31,7 @@ from huggingface_hub import InferenceClient
 ## Necesitas un token de https://hf.co/settings/tokens, asegúrate de seleccionar 'read' como tipo de token. Si ejecutas esto en Google Colab, puedes configurarlo en la pestaña "settings" bajo "secrets". Asegúrate de llamarlo "HF_TOKEN"
 os.environ["HF_TOKEN"]="hf_xxxxxxxxxxxxxx"
 
-client = InferenceClient("meta-llama/Llama-3.2-3B-Instruct")
+client = InferenceClient("meta-llama/Llama-3.3-70B-Instruct")
 # si las salidas para las siguientes celdas son incorrectas, el modelo gratuito puede estar sobrecargado. También puedes usar este endpoint público que contiene Llama-3.2-3B-Instruct
 # client = InferenceClient("https://jc26mwg228mkj8dw.us-east-1.aws.endpoints.huggingface.cloud")
 ```

--- a/units/es/unit1/what-are-llms.mdx
+++ b/units/es/unit1/what-are-llms.mdx
@@ -214,7 +214,7 @@ Si deseas profundizar aún más en el fascinante mundo de los modelos de lenguaj
 
 Ahora que entendemos cómo funcionan los LLMs, es hora de ver **cómo los LLMs estructuran sus generaciones en un contexto conversacional**.
 
-Para ejecutar <a href="https://huggingface.co/agents-course/notebooks/blob/main/dummy_agent_library.ipynb" target="_blank">este notebook</a>, **necesitas un token de Hugging Face** que puedes obtener de <a href="https://hf.co/settings/tokens" target="_blank">https://hf.co/settings/tokens</a>.
+Para ejecutar <a href="https://huggingface.co/agents-course/notebooks/blob/main/unit1/dummy_agent_library.ipynb" target="_blank">este notebook</a>, **necesitas un token de Hugging Face** que puedes obtener de <a href="https://hf.co/settings/tokens" target="_blank">https://hf.co/settings/tokens</a>.
 
 Para más información sobre cómo ejecutar Jupyter Notebooks, consulta <a href="https://huggingface.co/docs/hub/notebooks">Jupyter Notebooks en el Hugging Face Hub</a>.
 

--- a/units/es/unit2/smolagents/code_agents.mdx
+++ b/units/es/unit2/smolagents/code_agents.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/code_agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/code_agents.ipynb"},
 ]} />
 
 # Construcción de Agentes que Usan Código

--- a/units/es/unit2/smolagents/multi_agent_systems.mdx
+++ b/units/es/unit2/smolagents/multi_agent_systems.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/multiagent_notebook.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/multiagent_notebook.ipynb"},
 ]} />
 
 # Sistemas Multi-Agente

--- a/units/es/unit2/smolagents/retrieval_agents.mdx
+++ b/units/es/unit2/smolagents/retrieval_agents.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/retrieval_agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/retrieval_agents.ipynb"},
 ]} />
 
 # Construyendo Sistemas RAG con Agentes

--- a/units/es/unit2/smolagents/tool_calling_agents.mdx
+++ b/units/es/unit2/smolagents/tool_calling_agents.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/tool_calling_agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/tool_calling_agents.ipynb"},
 ]} />
 
 # Escribiendo acciones como fragmentos de código o estructuras JSON

--- a/units/es/unit2/smolagents/tools.mdx
+++ b/units/es/unit2/smolagents/tools.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/tools.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/tools.ipynb"},
 ]} />
 
 # Herramientas  

--- a/units/es/unit2/smolagents/vision_agents.mdx
+++ b/units/es/unit2/smolagents/vision_agents.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/vision_agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/vision_agents.ipynb"},
 ]} />
 
 # Agentes de Visión con smolagents

--- a/units/ru-RU/unit1/dummy-agent-library.mdx
+++ b/units/ru-RU/unit1/dummy-agent-library.mdx
@@ -18,7 +18,7 @@
 
 Мы будем использовать встроенные пакеты Python, такие как `datetime` и `os`, чтобы вы могли попробовать его в любом окружении.
 
-Вы можете отслеживать процесс [в этом блокноте](https://huggingface.co/agents-course/notebooks/blob/main/dummy_agent_library.ipynb) и **запустите код самостоятельно**.
+Вы можете отслеживать процесс [в этом блокноте](https://huggingface.co/agents-course/notebooks/blob/main/unit1/dummy_agent_library.ipynb) и **запустите код самостоятельно**.
 
 ## Бессерверный API
 
@@ -31,7 +31,7 @@ from huggingface_hub import InferenceClient
 ## Вам нужен токен с сайта https://hf.co/settings/tokens, убедитесь, что в качестве типа токена выбран 'read'. Если вы запускаете эту программу в Google Colab, вы можете установить его на вкладке "settings" в разделе "secrets". Обязательно назовите его "HF_TOKEN"
 os.environ["HF_TOKEN"]="hf_xxxxxxxxxxxxxx"
 
-client = InferenceClient("meta-llama/Llama-3.2-3B-Instruct")
+client = InferenceClient("meta-llama/Llama-3.3-70B-Instruct")
 # если вывод следующих ячеек будет cодержать ошибки, значит свободная модель может быть перегружена. Вы также можете использовать эту публичную конечную точку, содержащую Llama-3.2-3B-Instruct
 # client = InferenceClient("https://jc26mwg228mkj8dw.us-east-1.aws.endpoints.huggingface.cloud")
 ```

--- a/units/ru-RU/unit1/what-are-llms.mdx
+++ b/units/ru-RU/unit1/what-are-llms.mdx
@@ -216,7 +216,7 @@ LLM являются ключевым компонентом агентов ис
 
 Теперь, когда мы поняли, как работают LLM, пришло время увидеть **как LLM структурируют свою генерацию в разговорном контексте**.
 
-Чтобы запустить <a href="https://huggingface.co/agents-course/notebooks/blob/main/dummy_agent_library.ipynb" target="_blank">этот блокнот</a>, **вам понадобится токен Hugging Face** который вы можете получить из <a href="https://hf.co/settings/tokens" target="_blank">https://hf.co/settings/tokens</a>.
+Чтобы запустить <a href="https://huggingface.co/agents-course/notebooks/blob/main/unit1/dummy_agent_library.ipynb" target="_blank">этот блокнот</a>, **вам понадобится токен Hugging Face** который вы можете получить из <a href="https://hf.co/settings/tokens" target="_blank">https://hf.co/settings/tokens</a>.
 
 Более подробную информацию о том, как запустить блокноты Jupyter, изучите <a href="https://huggingface.co/docs/hub/notebooks">Блокноты Jupyter на Hugging Face Hub</a>.
 

--- a/units/vi/unit1/dummy-agent-library.mdx
+++ b/units/vi/unit1/dummy-agent-library.mdx
@@ -18,7 +18,7 @@ Sau phần này, bạn sẽ sẵn sàng **tạo Agent đơn giản** bằng `smo
 
 Chúng mình sẽ sử dụng các package Python tích hợp sẵn như `datetime` và `os` để bạn có thể chạy thử trong mọi môi trường.
 
-Bạn có thể theo dõi quy trình [trong notebook này](https://huggingface.co/agents-course/notebooks/blob/main/dummy_agent_library.ipynb) và **tự chạy code**.
+Bạn có thể theo dõi quy trình [trong notebook này](https://huggingface.co/agents-course/notebooks/blob/main/unit1/dummy_agent_library.ipynb) và **tự chạy code**.
 
 ## Serverless API
 
@@ -33,7 +33,7 @@ from huggingface_hub import InferenceClient
 ## Bạn cần token từ https://hf.co/settings/tokens, chọn loại token 'read'. Nếu chạy trên Google Colab, hãy thiết lập trong tab "settings" mục "secrets". Đặt tên secret là "HF_TOKEN"
 os.environ["HF_TOKEN"]="hf_xxxxxxxxxxxxxx"
 
-client = InferenceClient("meta-llama/Llama-3.2-3B-Instruct")
+client = InferenceClient("meta-llama/Llama-3.3-70B-Instruct")
 # nếu đầu ra sai ở các cell sau, mô hình miễn phí có thể đang quá tải. Bạn cũng có thể dùng public endpoint này chứa Llama-3.2-3B-Instruct
 # client = InferenceClient("https://jc26mwg228mkj8dw.us-east-1.aws.endpoints.huggingface.cloud")
 ```

--- a/units/vi/unit1/what-are-llms.mdx
+++ b/units/vi/unit1/what-are-llms.mdx
@@ -212,7 +212,7 @@ Nếu muốn khám phá sâu hơn về mô hình ngôn ngữ và xử lý ngôn 
 
 Giờ đã hiểu cách LLM hoạt động, hãy xem **cách LLM cấu trúc output trong ngữ cảnh hội thoại**.
 
-Để chạy [notebook này](https://huggingface.co/agents-course/notebooks/blob/main/dummy_agent_library.ipynb), **bạn cần Hugging Face token** lấy từ [https://hf.co/settings/tokens](https://hf.co/settings/tokens).
+Để chạy [notebook này](https://huggingface.co/agents-course/notebooks/blob/main/unit1/dummy_agent_library.ipynb), **bạn cần Hugging Face token** lấy từ [https://hf.co/settings/tokens](https://hf.co/settings/tokens).
 
 Xem thêm hướng dẫn chạy Jupyter Notebook tại [Jupyter Notebooks on the Hugging Face Hub](https://huggingface.co/docs/hub/notebooks).
 

--- a/units/zh-CN/bonus_unit2/monitoring-and-evaluating-agents-notebook.mdx
+++ b/units/zh-CN/bonus_unit2/monitoring-and-evaluating-agents-notebook.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/bonus-unit2/monitoring-and-evaluating-agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/bonus-unit2/monitoring-and-evaluating-agents.ipynb"},
 ]} />
 
 # 附加单元 2：AI 智能体(AI Agent)的可观测性与评估

--- a/units/zh-CN/unit1/dummy-agent-library.mdx
+++ b/units/zh-CN/unit1/dummy-agent-library.mdx
@@ -18,7 +18,7 @@
 
 我们将使用内置的 Python 包，如 `datetime` 和 `os`，这样你可以在任何环境中尝试它。
 
-你可以[在这个 notebook 中](https://huggingface.co/agents-course/notebooks/blob/main/dummy_agent_library.ipynb)跟随过程并**自己运行代码**。
+你可以[在这个 notebook 中](https://huggingface.co/agents-course/notebooks/blob/main/unit1/dummy_agent_library.ipynb)跟随过程并**自己运行代码**。
 
 ## 无服务器 API (Serverless API)
 
@@ -31,7 +31,7 @@ from huggingface_hub import InferenceClient
 ## 你需要一个来自 https://hf.co/settings/tokens 的令牌，确保你选择'read'作为令牌类型。如果你在 Google Colab 上运行，你可以在"settings"标签下的"secrets"中设置它。确保将其命名为"HF_TOKEN"
 os.environ["HF_TOKEN"]="hf_xxxxxxxxxxxxxx"
 
-client = InferenceClient("meta-llama/Llama-3.2-3B-Instruct")
+client = InferenceClient("meta-llama/Llama-3.3-70B-Instruct")
 # 如果下一个单元格的输出不正确，免费模型可能过载。你也可以使用这个包含 Llama-3.2-3B-Instruct 的公共端点
 # client = InferenceClient("https://jc26mwg228mkj8dw.us-east-1.aws.endpoints.huggingface.cloud")
 ```

--- a/units/zh-CN/unit1/what-are-llms.mdx
+++ b/units/zh-CN/unit1/what-are-llms.mdx
@@ -216,7 +216,7 @@ Transformer 架构的一个关键方面是**注意力机制**。在预测下一�
 
 现在我们已经了解了大语言模型的工作原理，接下来是时候看看**大语言模型如何在对话语境中构建其生成内容**了。
 
-要运行<a href="https://huggingface.co/agents-course/notebooks/blob/main/dummy_agent_library.ipynb" target="_blank">这个笔记本</a>，**你需要一个 Hugging Face 令牌**，你可以从<a href="https://hf.co/settings/tokens" target="_blank"> https://hf.co/settings/tokens </a>获取。
+要运行<a href="https://huggingface.co/agents-course/notebooks/blob/main/unit1/dummy_agent_library.ipynb" target="_blank">这个笔记本</a>，**你需要一个 Hugging Face 令牌**，你可以从<a href="https://hf.co/settings/tokens" target="_blank"> https://hf.co/settings/tokens </a>获取。
 
 有关如何运行 Jupyter Notebook 的更多信息，请查看<a href="https://huggingface.co/docs/hub/notebooks"> Hugging Face Hub 上的 Jupyter Notebook</a>。
 

--- a/units/zh-CN/unit2/smolagents/code_agents.mdx
+++ b/units/zh-CN/unit2/smolagents/code_agents.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/code_agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/code_agents.ipynb"},
 ]} />
 
 # 构建使用代码的智能体

--- a/units/zh-CN/unit2/smolagents/multi_agent_systems.mdx
+++ b/units/zh-CN/unit2/smolagents/multi_agent_systems.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/multiagent_notebook.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/multiagent_notebook.ipynb"},
 ]} />
 
 # 多智能体系统

--- a/units/zh-CN/unit2/smolagents/retrieval_agents.mdx
+++ b/units/zh-CN/unit2/smolagents/retrieval_agents.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/retrieval_agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/retrieval_agents.ipynb"},
 ]} />
 
 # 构建智能驱动的 RAG 系统

--- a/units/zh-CN/unit2/smolagents/tool_calling_agents.mdx
+++ b/units/zh-CN/unit2/smolagents/tool_calling_agents.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/tool_calling_agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/tool_calling_agents.ipynb"},
 ]} />
 
 # 将操作编写为代码片段或 JSON 结构

--- a/units/zh-CN/unit2/smolagents/tools.mdx
+++ b/units/zh-CN/unit2/smolagents/tools.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/tools.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/tools.ipynb"},
 ]} />
 
 # 工具

--- a/units/zh-CN/unit2/smolagents/vision_agents.mdx
+++ b/units/zh-CN/unit2/smolagents/vision_agents.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/vision_agents.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/#fileId=https://huggingface.co/agents-course/notebooks/blob/main/unit2/smolagents/vision_agents.ipynb"},
 ]} />
 
 # 使用 smolagents 构建视觉智能体


### PR DESCRIPTION
This PR and [this one](https://huggingface.co/agents-course/notebooks/discussions/87) need to be merged together in order to work.

Moved all the notebook references to link HF Orgs notebooks and keep that as a source of truth.
We can even remove the notebooks from this repo to avoid duplications.

@burtenshaw 