### PR TITLE
Fix Unit 1 dummy_agent_library.ipynb ValueError

### DIFF
--- a/notebooks/unit1/dummy_agent_library.ipynb
+++ b/notebooks/unit1/dummy_agent_library.ipynb
@@ -64,7 +64,7 @@
     "\n",
     "\n",
     "\n",
-    "client = InferenceClient(\"meta-llama/Llama-3.3-70B-Instruct\")\n",
+    "client = InferenceClient(provider=\"hf-inference\", model=\"meta-llama/Llama-3.3-70B-Instruct\")\n",
     "# if the outputs for next cells are wrong, the free model may be overloaded. You can also use this public endpoint that contains Llama-3.3-70B-Instruct\n",
     "#client = InferenceClient(\"https://jc26mwg228mkj8dw.us-east-1.aws.endpoints.huggingface.cloud\")"
    ]


### PR DESCRIPTION

## Description

This pull request addresses [huggingface/agents-course#487](https://github.com/huggingface/agents-course/issues/487), which reports an issue in Unit 1 ("Dummy Agents Library" section) of the AI Agents course. The provided code attempts to use the `meta-llama/Llama-3.2-3B-Instruct` model for text generation, resulting in a `ValueError`:

```

ValueError: Model meta-llama/Llama-3.2-3B-Instruct is not supported for task text-generation and provider together. Supported task: conversational.

````

This indicates that the selected model is not compatible with the `text-generation` task as expected in the course materials.

## Fix

The following line:

```python
client = InferenceClient("meta-llama/Llama-3.3-70B-Instruct")
````

has been updated to:

```python
client = InferenceClient(provider="hf-inference", model="meta-llama/Llama-3.3-70B-Instruct")
```

This explicitly sets the provider to `hf-inference` and uses a compatible model for the intended task.

## Outcome

The updated code resolves the model compatibility error and allows the example in Unit 1 to execute successfully.

## Linked Issue

Fixes huggingface/agents-course#487

