### PR TITLE
Fix: Unit 2.2 - Using Tools in Llama Index - Documentation 404 Not Found

### DIFF
--- a/units/en/unit2/llama-index/tools.mdx
+++ b/units/en/unit2/llama-index/tools.mdx
@@ -41,7 +41,7 @@ tool = FunctionTool.from_defaults(
 tool.call("New York")
 ```
 
-<Tip>When using an agent or LLM with function calling, the tool selected (and the arguments written for that tool) rely strongly on the tool name and description of the purpose and arguments of the tool. Learn more about function calling in the <a href="https://docs.llamaindex.ai/en/stable/module_guides/deploying/agents/tools/">Function Calling Guide</a> and <a href="https://docs.llamaindex.ai/en/stable/understanding/agent/">Function Calling Learning Guide</a>.</Tip>
+<Tip>When using an agent or LLM with function calling, the tool selected (and the arguments written for that tool) rely strongly on the tool name and description of the purpose and arguments of the tool. Learn more about function calling in the <a href="https://docs.llamaindex.ai/en/stable/examples/workflow/function_calling_agent/">Function Calling Guide</a></Tip>
 
 ## Creating a QueryEngineTool
 

--- a/units/en/unit2/llama-index/tools.mdx
+++ b/units/en/unit2/llama-index/tools.mdx
@@ -41,7 +41,7 @@ tool = FunctionTool.from_defaults(
 tool.call("New York")
 ```
 
-<Tip>When using an agent or LLM with function calling, the tool selected (and the arguments written for that tool) rely strongly on the tool name and description of the purpose and arguments of the tool. Learn more about function calling in the <a href="https://docs.llamaindex.ai/en/stable/module_guides/deploying/agents/modules/function_calling.html">Function Calling Guide</a> and <a href="https://docs.llamaindex.ai/en/stable/understanding/agent/function_calling.html">Function Calling Learning Guide</a>.</Tip>
+<Tip>When using an agent or LLM with function calling, the tool selected (and the arguments written for that tool) rely strongly on the tool name and description of the purpose and arguments of the tool. Learn more about function calling in the <a href="https://docs.llamaindex.ai/en/stable/module_guides/deploying/agents/modules">Function Calling Guide</a> and <a href="https://docs.llamaindex.ai/en/stable/understanding/agent/">Function Calling Learning Guide</a>.</Tip>
 
 ## Creating a QueryEngineTool
 

--- a/units/en/unit2/llama-index/tools.mdx
+++ b/units/en/unit2/llama-index/tools.mdx
@@ -41,7 +41,7 @@ tool = FunctionTool.from_defaults(
 tool.call("New York")
 ```
 
-<Tip>When using an agent or LLM with function calling, the tool selected (and the arguments written for that tool) rely strongly on the tool name and description of the purpose and arguments of the tool. Learn more about function calling in the <a href="https://docs.llamaindex.ai/en/stable/module_guides/deploying/agents/modules">Function Calling Guide</a> and <a href="https://docs.llamaindex.ai/en/stable/understanding/agent/">Function Calling Learning Guide</a>.</Tip>
+<Tip>When using an agent or LLM with function calling, the tool selected (and the arguments written for that tool) rely strongly on the tool name and description of the purpose and arguments of the tool. Learn more about function calling in the <a href="https://docs.llamaindex.ai/en/stable/module_guides/deploying/agents/tools/">Function Calling Guide</a> and <a href="https://docs.llamaindex.ai/en/stable/understanding/agent/">Function Calling Learning Guide</a>.</Tip>
 
 ## Creating a QueryEngineTool
 

--- a/units/en/unit2/llama-index/tools.mdx
+++ b/units/en/unit2/llama-index/tools.mdx
@@ -41,7 +41,7 @@ tool = FunctionTool.from_defaults(
 tool.call("New York")
 ```
 
-<Tip>When using an agent or LLM with function calling, the tool selected (and the arguments written for that tool) rely strongly on the tool name and description of the purpose and arguments of the tool. Learn more about function calling in the <a href="https://docs.llamaindex.ai/en/stable/examples/workflow/function_calling_agent/">Function Calling Guide</a></Tip>
+<Tip>When using an agent or LLM with function calling, the tool selected (and the arguments written for that tool) rely strongly on the tool name and description of the purpose and arguments of the tool. Learn more about function calling in the <a href="https://docs.llamaindex.ai/en/stable/examples/workflow/function_calling_agent/">Function Calling Guide</a>.</Tip>
 
 ## Creating a QueryEngineTool
 

--- a/units/es/unit2/llama-index/tools.mdx
+++ b/units/es/unit2/llama-index/tools.mdx
@@ -41,7 +41,7 @@ tool = FunctionTool.from_defaults(
 tool.call("Nuevo York")
 ```
 
-<Tip>Cuando se utiliza un agente o LLM con llamadas a funciones, la herramienta seleccionada (y los argumentos escritos para esa herramienta) dependen en gran medida del nombre de la herramienta y la descripción del proposito y argumentos de la herramienta. Aprende más sobre la llamada a funciones en la <a href="https://docs.llamaindex.ai/es/stable/module_guides/deploying/agents/modules/function_calling.html">Guía de llamada a funciones</a> y <a href="https://docs.llamaindex.ai/es/stable/understanding/agent/function_calling.html">Guía de aprendizaje de llamada a funciones</a>.</Tip>
+<Tip>Cuando se utiliza un agente o LLM con llamadas a funciones, la herramienta seleccionada (y los argumentos escritos para esa herramienta) dependen en gran medida del nombre de la herramienta y la descripción del proposito y argumentos de la herramienta. Aprende más sobre la llamada a funciones en la <a href="https://docs.llamaindex.ai/en/stable/module_guides/deploying/agents/tools/">Guía de llamada a funciones</a> y <a href="https://docs.llamaindex.ai/es/stable/understanding/agent/">Guía de aprendizaje de llamada a funciones</a>.</Tip>
 
 ## Creando un QueryEngineTool
 

--- a/units/es/unit2/llama-index/tools.mdx
+++ b/units/es/unit2/llama-index/tools.mdx
@@ -38,7 +38,7 @@ tool = FunctionTool.from_defaults(
     name="my_weather_tool",
     description="Útil para obtener el clima para una ubicación determinada.",
 )
-tool.call("Nuevo Yorkii")
+tool.call("Nuevo York")
 ```
 
 <Tip>Cuando se utiliza un agente o LLM con llamadas a funciones, la herramienta seleccionada (y los argumentos escritos para esa herramienta) dependen en gran medida del nombre de la herramienta y la descripción del proposito y argumentos de la herramienta. Aprende más sobre la llamada a funciones en la <a href="https://docs.llamaindex.ai/en/stable/examples/workflow/function_calling_agent/">Guía de llamada a funciones</a>.</Tip>

--- a/units/es/unit2/llama-index/tools.mdx
+++ b/units/es/unit2/llama-index/tools.mdx
@@ -38,10 +38,10 @@ tool = FunctionTool.from_defaults(
     name="my_weather_tool",
     description="Útil para obtener el clima para una ubicación determinada.",
 )
-tool.call("Nuevo York")
+tool.call("Nuevo Yorkii")
 ```
 
-<Tip>Cuando se utiliza un agente o LLM con llamadas a funciones, la herramienta seleccionada (y los argumentos escritos para esa herramienta) dependen en gran medida del nombre de la herramienta y la descripción del proposito y argumentos de la herramienta. Aprende más sobre la llamada a funciones en la <a href="https://docs.llamaindex.ai/en/stable/module_guides/deploying/agents/tools/">Guía de llamada a funciones</a> y <a href="https://docs.llamaindex.ai/es/stable/understanding/agent/">Guía de aprendizaje de llamada a funciones</a>.</Tip>
+<Tip>Cuando se utiliza un agente o LLM con llamadas a funciones, la herramienta seleccionada (y los argumentos escritos para esa herramienta) dependen en gran medida del nombre de la herramienta y la descripción del proposito y argumentos de la herramienta. Aprende más sobre la llamada a funciones en la <a href="https://docs.llamaindex.ai/en/stable/examples/workflow/function_calling_agent/">Guía de llamada a funciones</a>.</Tip>
 
 ## Creando un QueryEngineTool
 

--- a/units/zh-CN/unit2/llama-index/tools.mdx
+++ b/units/zh-CN/unit2/llama-index/tools.mdx
@@ -41,7 +41,7 @@ tool = FunctionTool.from_defaults(
 tool.call("New York")
 ```
 
-<Tip>使用带有函数调用的智能体或 LLM 时，所选工具（以及为该工具编写的参数）在很大程度上取决于工具名称以及工具用途和参数的描述。在<a href="https://docs.llamaindex.ai/en/stable/module_guides/deploying/agents/modules/function_calling.html">函数调用指南</a>和<a href="https://docs.llamaindex.ai/en/stable/understanding/agent/function_calling.html">函数调用学习指南</a>中了解有关函数调用的更多信息。</Tip>
+<Tip>使用带有函数调用的智能体或 LLM 时，所选工具（以及为该工具编写的参数）在很大程度上取决于工具名称以及工具用途和参数的描述。在<a href="https://docs.llamaindex.ai/en/stable/examples/workflow/function_calling_agent/">函数调用指南</a>。</Tip>
 
 ## 创建 QueryEngineTool
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/96ad7bf9-71e5-4bea-8bab-f14a98c9c0a0)
[Function Calling Guide](https://docs.llamaindex.ai/en/stable/module_guides/deploying/agents/modules/function_calling.html) and [Function Calling Learning Guide](https://docs.llamaindex.ai/en/stable/understanding/agent/function_calling.html) Link to a  page Not Found

### Updated to:
[Function Calling Guide](https://docs.llamaindex.ai/en/stable/module_guides/deploying/agents/tools/) and [Function Calling Learning Guide](https://docs.llamaindex.ai/en/stable/understanding/agent/)