### PR TITLE
fix minor typo in tools.mdx

### DIFF
--- a/units/en/unit1/tools.mdx
+++ b/units/en/unit1/tools.mdx
@@ -152,7 +152,7 @@ class Tool:
         name (str): Name of the tool.
         description (str): A textual description of what the tool does.
         func (callable): The function this tool wraps.
-        arguments (list): A list of argument.
+        arguments (list): A list of arguments.
         outputs (str or list): The return type(s) of the wrapped function.
     """
     def __init__(self,


### PR DESCRIPTION
pluralize "arguments" in "A list of arguments" docstring for the Tool class