### PR TITLE
put serpapi key into correct env var

### DIFF
--- a/units/en/unit2/smolagents/multi_agent_systems.mdx
+++ b/units/en/unit2/smolagents/multi_agent_systems.mdx
@@ -126,7 +126,7 @@ print(calculate_cargo_travel_time((41.8781, -87.6298), (-33.8688, 151.2093)))
 
 For the model provider, we use Together AI, one of the new [inference providers on the Hub](https://huggingface.co/blog/inference-providers)!
 
-The GoogleSearchTool uses the [Serper API](https://serper.dev) to search the web, so this requires either having setup env variable `SERPER_API_KEY` and passing `provider="serpapi"` or having `SERPER_API_KEY` and passing `provider=serper`.
+The GoogleSearchTool uses the [Serper API](https://serper.dev) to search the web, so this requires either having setup env variable `SERPAPI_API_KEY` and passing `provider="serpapi"` or having `SERPER_API_KEY` and passing `provider=serper`.
 
 If you don't have any Serp API provider setup, you can use `DuckDuckGoSearchTool` but beware that it has a rate limit.
 


### PR DESCRIPTION
the serpapi api key goes in SERPAPI_API_KEY not SERPER_API_KEY.

the words are very close together (serper, serpapi) so it's hard to distinguish.