### PR TITLE
Corrected langfuse langchain callback

### DIFF
--- a/units/en/unit2/langgraph/first_graph.mdx
+++ b/units/en/unit2/langgraph/first_graph.mdx
@@ -323,7 +323,7 @@ os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com" # 🇪🇺 EU region
 Then, we configure the [Langfuse `callback_handler`](https://langfuse.com/docs/integrations/langchain/tracing#add-langfuse-to-your-langchain-application) and instrument the agent by adding the `langfuse_callback` to the invocation of the graph: `config={"callbacks": [langfuse_handler]}`.
 
 ```python   
-from langfuse.callback import CallbackHandler
+from langfuse.langchain import CallbackHandler
 
 # Initialize Langfuse CallbackHandler for LangGraph/Langchain (tracing)
 langfuse_handler = CallbackHandler()


### PR DESCRIPTION
As per Python SDK v3 should be CallbackHandler is in  langfuse.langchain, not langfuse.callback.