### PR TITLE
[UPDATE] Fix typo issue -  retrieval_agents.mdx 

### DIFF
--- a/units/en/unit2/smolagents/retrieval_agents.mdx
+++ b/units/en/unit2/smolagents/retrieval_agents.mdx
@@ -153,7 +153,7 @@ This enhanced agent can:
 When building agentic RAG systems, the agent can employ sophisticated strategies like:
 
 1. **Query Reformulation:** Instead of using the raw user query, the agent can craft optimized search terms that better match the target documents
-2. **Query Decomposition:** Istead of using the user query directly, if it contains multiple pieces of information to query, it can be decomposed to multiple queries
+2. **Query Decomposition:** Instead of using the user query directly, if it contains multiple pieces of information to query, it can be decomposed to multiple queries
 3. **Query Expansion:** Somehow similar to Query Reformulation but done multiple times to put the query in multiple wordings to query them all
 4. **Reranking:** Using Cross-Encoders to assign more comprehensive and semantic relevance scores between retrieved documents and search query
 5. **Multi-Step Retrieval:** The agent can perform multiple searches, using initial results to inform subsequent queries


### PR DESCRIPTION
FROM
Query Decomposition: **Istead** of using the user query directly, if it contains multiple pieces of information to query, it can be decomposed to multiple queries


TO 

Query Decomposition: **Instead** of using the user query directly, if it contains multiple pieces of information to query, it can be decomposed to multiple queries