### PR TITLE
Remove the deadline and put the game in self-pace mode

### DIFF
--- a/units/en/unit0/introduction.mdx
+++ b/units/en/unit0/introduction.mdx
@@ -61,9 +61,7 @@ Here is the **general syllabus for the course**. A more detailed list of topics 
 | :---- | :---- | :---- |
 | 0 | Onboarding | Set you up with the tools and platforms that you will use. |
 | 1 | Agent Fundamentals | Explain Tools, Thoughts, Actions, Observations, and their formats. Explain LLMs, messages, special tokens and chat templates. Show a simple use case using python functions as tools. |
-| 1.5 | Bonus : Fine-tuning an LLM for function calling | Let's use LoRa and fine-tune a model to perform function calling inside a notebook. |
 | 2 | Frameworks | Understand how the fundamentals are implemented in popular libraries : smolagents, LangGraph, LLamaIndex |
-| 2.5 | Bonus : Agent Observability and Evaluation | Learn how to trace and evaluate your AI agents to make them ready for production. |
 | 3 | Use Cases | Let's build some real life use cases (open to PRs 🤗 from experienced Agent builders) |
 | 4 | Final Assignment | Build an agent for a selected benchmark and prove your understanding of Agents on the student leaderboard  🚀 |
 
@@ -103,15 +101,13 @@ The certification process is **completely free**:
 - *To get a certification for fundamentals*: you need to complete Unit 1 of the course. This is intended for students that want to get up to date with the latest trends in Agents.
 - *To get a certificate of completion*: you need to complete Unit 1, one of the use case assignments we'll propose during the course, and the final challenge.
 
-There's a deadline for the certification process: all the assignments must be finished before **July 1st 2025**.
-
-<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit0/deadline.jpg" alt="Deadline" width="100%"/>
+There's **no deadline** for the certification process.
 
 ## What is the recommended pace? [[recommended-pace]]
 
 Each chapter in this course is designed **to be completed in 1 week, with approximately 3-4 hours of work per week**.
 
-Since there's a deadline, we provide you a recommended pace:
+We provide you a recommended pace:
 
 <img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit0/recommended-pace.jpg" alt="Recommended Pace" width="100%"/>
 

--- a/units/en/unit0/introduction.mdx
+++ b/units/en/unit0/introduction.mdx
@@ -15,7 +15,7 @@ This first unit will help you onboard:
 
 - Discover the **course's syllabus**.
 - **Choose the path** you're going to take (either self-audit or certification process).
-- **Get more information about the certification process and the deadlines**.
+- **Get more information about the certification process**.
 - Get to know the team behind the course.
 - Create your **Hugging Face account**.
 - **Sign-up to our Discord server**, and meet your classmates and us.


### PR DESCRIPTION
Context:
- The deadline for certification was 1st of July.
- Because a lot of students are currently doing the course and a lot more will signup in the upcoming months, we decided to remove the deadline and put the course in self-paced mode.

What I did:
✅  Update illustrations on deadlines
✅ Update the course
✅ Update the emails for the course (that contains the deadline info).
✅ Some cleanups.