### PR TITLE
Document class in Langchain has been moved to langchain_core from langchain.docstore

### DIFF
--- a/units/en/unit3/agentic-rag/invitees.mdx
+++ b/units/en/unit3/agentic-rag/invitees.mdx
@@ -82,7 +82,7 @@ We will use the Hugging Face `datasets` library to load the dataset and convert 
 
 ```python
 import datasets
-from langchain.docstore.document import Document
+from langchain_core.documents import Document
 
 # Load the dataset
 guest_dataset = datasets.load_dataset("agents-course/unit3-invitees", split="train")


### PR DESCRIPTION
I have noticed that the `Document` class from `langchain.doctore.document` has moved to `langchain_core.documents` in the latest version of LangChain. I have modified the particular section in the code snippet.

