### PR TITLE
docs: clarify Chain-of-Thought vs ReAct in Unit 1 thoughts section

### DIFF
--- a/units/en/unit1/thoughts.mdx
+++ b/units/en/unit1/thoughts.mdx
@@ -54,3 +54,95 @@ These models have been trained to always include specific _thinking_ sections (e
 
 --- 
 Now that we better understand the Thought process, let's go deeper on the second part of the process: Act.
+
+# Thought: Internal Reasoning, Chain-of-Thought (CoT), and the ReAct Approach
+
+<Tip> 
+In this section, we dive into the inner workings of an AI agent—its ability to reason and plan. We’ll explore how the agent leverages internal dialogue to analyze information, break down complex problems into manageable steps, and decide what action to take next. We also clarify the distinction between two powerful prompting techniques: **Chain-of-Thought (CoT)** and **ReAct**.
+</Tip>
+
+Thoughts represent the **Agent's internal reasoning and planning processes** to solve a task.
+
+This leverages the agent's Large Language Model (LLM) capacity **to analyze information presented in its prompt** — essentially, its inner monologue as it works through a problem.
+
+The Agent's thoughts help it assess current observations and decide what the next action(s) should be. This process allows the agent to **break down complex problems into manageable sub-tasks**, reflect on past experience, and adapt plans based on new information.
+
+---
+
+## 🧠 Examples of Common Thought Types
+
+| Type of Thought    | Example                                                                 |
+|--------------------|-------------------------------------------------------------------------|
+| Planning           | "I need to break this task into three steps: 1) gather data, 2) analyze trends, 3) generate report" |
+| Analysis           | "Based on the error message, the issue appears to be with the database connection parameters" |
+| Decision Making    | "Given the user's budget constraints, I should recommend the mid-tier option" |
+| Problem Solving    | "To optimize this code, I should first profile it to identify bottlenecks" |
+| Memory Integration | "The user mentioned their preference for Python earlier, so I'll provide examples in Python" |
+| Self-Reflection    | "My last approach didn't work well, I should try a different strategy" |
+| Goal Setting       | "To complete this task, I need to first establish the acceptance criteria" |
+| Prioritization     | "The security vulnerability should be addressed before adding new features" |
+
+> **Note:** In the case of LLMs fine-tuned for function-calling, the thought process is optional.
+> If you're not familiar with function-calling yet, more details will come in the Actions section.
+
+---
+
+## 🔗 Chain-of-Thought (CoT)
+
+**Chain-of-Thought (CoT)** is a prompting technique that guides a model to **think through a problem step-by-step before producing a final answer.**
+
+It typically starts with:  
+> *"Let's think step by step."*
+
+This approach helps the model **reason internally**, especially for logical or mathematical tasks, **without interacting with external tools**.
+
+### ✅ Example (CoT)
+
+```
+Question: What is 15% of 200?
+Thought: Let's think step by step. 10% of 200 is 20, and 5% of 200 is 10, so 15% is 30.
+Answer: 30
+```
+
+---
+
+## ⚙️ ReAct: Reasoning + Acting
+
+**ReAct** stands for **Reasoning and Acting**. It extends CoT by introducing **external actions** between thoughts. This includes using tools (e.g., calculator, search engine) to gather information, followed by observations that feed into the next reasoning step.
+
+### 🔄 Example (ReAct)
+
+```
+Thought: I need to find the latest weather in Paris.
+Action: Search["weather in Paris"]
+Observation: It's 18°C and cloudy.
+Thought: Now that I know the weather...
+Action: Finish["It's 18°C and cloudy in Paris."]
+```
+
+<figure>
+  <img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit1/ReAct.png" alt="ReAct"/>
+  <figcaption>
+    (d) is an example of the ReAct approach, where we prompt "Let's think step by step", and the model acts between thoughts.
+  </figcaption>
+</figure>
+
+---
+
+## 🔁 Comparison: ReAct vs. CoT
+
+| Feature              | CoT                         | ReAct                              |
+|----------------------|-----------------------------|------------------------------------|
+| Step-by-step logic   | Yes                         | Yes                                |
+| Uses external tools  | No                          | Yes (Actions + Observations)       |
+| Best for             | Logic, math, internal tasks | Multi-step tasks requiring info    |
+
+<Tip>
+Recent models like Deepseek R1 or OpenAI’s o1 were fine-tuned to think before answering. They often use structured tokens like `<think>` and `</think>` to explicitly separate the reasoning phase from the final answer.
+
+Unlike ReAct or CoT — which are prompting strategies — this is a **training-level technique**, where the model learns to think via examples.
+</Tip>
+
+---
+
+Now that we understand internal reasoning and the ReAct method, let’s move on to the second part of the loop: **Act**.

--- a/units/en/unit1/thoughts.mdx
+++ b/units/en/unit1/thoughts.mdx
@@ -1,3 +1,4 @@
+
 # Thought: Internal Reasoning and the ReAct Approach
 
 <Tip> 
@@ -6,68 +7,10 @@ In this section, we dive into the inner workings of an AI agent—its ability to
 
 Thoughts represent the **Agent's internal reasoning and planning processes** to solve the task.
 
-This utilises the agent's Large Language Model (LLM) capacity **to analyze information when presented in its prompt**.
+This utilises the agent's Large Language Model (LLM) capacity **to analyze information when presented in its prompt** — essentially, its inner monologue as it works through a problem.
 
-Think of it as the agent's internal dialogue, where it considers the task at hand and strategizes its approach.
+The Agent's thoughts help it assess current observations and decide what the next action(s) should be. Through this process, the agent can **break down complex problems into smaller, more manageable steps**, reflect on past experiences, and continuously adjust its plans based on new information.
 
-The Agent's thoughts are responsible for assessing current observations and decide what the next action(s) should be.
-
-Through this process, the agent can **break down complex problems into smaller, more manageable steps**, reflect on past experiences, and continuously adjust its plans based on new information.
-
-Here are some examples of common thoughts:
-
-| Type of Thought | Example |
-|----------------|---------|
-| Planning | "I need to break this task into three steps: 1) gather data, 2) analyze trends, 3) generate report" |
-| Analysis | "Based on the error message, the issue appears to be with the database connection parameters" |
-| Decision Making | "Given the user's budget constraints, I should recommend the mid-tier option" |
-| Problem Solving | "To optimize this code, I should first profile it to identify bottlenecks" |
-| Memory Integration | "The user mentioned their preference for Python earlier, so I'll provide examples in Python" |
-| Self-Reflection | "My last approach didn't work well, I should try a different strategy" |
-| Goal Setting | "To complete this task, I need to first establish the acceptance criteria" |
-| Prioritization | "The security vulnerability should be addressed before adding new features" |
-
-> **Note:** In the case of LLMs fine-tuned for function-calling, the thought process is optional.
-> *In case you're not familiar with function-calling, there will be more details in the Actions section.*
-
-## The ReAct Approach
-
-A key method is the **ReAct approach**, which is the concatenation of  "Reasoning" (Think) with "Acting" (Act). 
-
-ReAct is a simple prompting technique that appends "Let's think step by step" before letting the LLM decode the next tokens. 
-
-Indeed, prompting the model to think "step by step" encourages the decoding process toward next tokens **that generate a plan**, rather than a final solution, since the model is encouraged to **decompose** the problem into *sub-tasks*.
-
-This allows the model to consider sub-steps in more detail, which in general leads to less errors than trying to generate the final solution directly.
-
-<figure>
-<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit1/ReAct.png" alt="ReAct"/>
-<figcaption>The (d) is an example of ReAct approach where we prompt "Let's think step by step"
-</figcaption>
-</figure>
-
-<Tip>
-We have recently seen a lot of interest for reasoning strategies. This is what's behind models like Deepseek R1 or OpenAI's o1, which have been fine-tuned to "think before answering".
-
-These models have been trained to always include specific _thinking_ sections (enclosed between `<think>` and `</think>` special tokens). This is not just a prompting technique like ReAct, but a training method where the model learns to generate these sections after analyzing thousands of examples that show what we expect it to do.
-</Tip>
-
---- 
-Now that we better understand the Thought process, let's go deeper on the second part of the process: Act.
-
-# Thought: Internal Reasoning, Chain-of-Thought (CoT), and the ReAct Approach
-
-<Tip> 
-In this section, we dive into the inner workings of an AI agent—its ability to reason and plan. We’ll explore how the agent leverages internal dialogue to analyze information, break down complex problems into manageable steps, and decide what action to take next. We also clarify the distinction between two powerful prompting techniques: **Chain-of-Thought (CoT)** and **ReAct**.
-</Tip>
-
-Thoughts represent the **Agent's internal reasoning and planning processes** to solve a task.
-
-This leverages the agent's Large Language Model (LLM) capacity **to analyze information presented in its prompt** — essentially, its inner monologue as it works through a problem.
-
-The Agent's thoughts help it assess current observations and decide what the next action(s) should be. This process allows the agent to **break down complex problems into manageable sub-tasks**, reflect on past experience, and adapt plans based on new information.
-
----
 
 ## 🧠 Examples of Common Thought Types
 
@@ -82,10 +25,8 @@ The Agent's thoughts help it assess current observations and decide what the nex
 | Goal Setting       | "To complete this task, I need to first establish the acceptance criteria" |
 | Prioritization     | "The security vulnerability should be addressed before adding new features" |
 
-> **Note:** In the case of LLMs fine-tuned for function-calling, the thought process is optional.
-> If you're not familiar with function-calling yet, more details will come in the Actions section.
+> **Note:** In the case of LLMs fine-tuned for function-calling, the thought process is optional. More details will be covered in the Actions section.
 
----
 
 ## 🔗 Chain-of-Thought (CoT)
 
@@ -97,21 +38,25 @@ It typically starts with:
 This approach helps the model **reason internally**, especially for logical or mathematical tasks, **without interacting with external tools**.
 
 ### ✅ Example (CoT)
-
 ```
 Question: What is 15% of 200?
 Thought: Let's think step by step. 10% of 200 is 20, and 5% of 200 is 10, so 15% is 30.
 Answer: 30
 ```
 
----
 
 ## ⚙️ ReAct: Reasoning + Acting
 
-**ReAct** stands for **Reasoning and Acting**. It extends CoT by introducing **external actions** between thoughts. This includes using tools (e.g., calculator, search engine) to gather information, followed by observations that feed into the next reasoning step.
+A key method is the **ReAct approach**, which combines "Reasoning" (Think) with "Acting" (Act). 
+
+ReAct is a prompting technique that encourages the model to think step-by-step and interleave actions (like using tools) between reasoning steps.
+
+This enables the agent to solve complex multi-step tasks by alternating between:
+- Thought: internal reasoning
+- Action: tool usage
+- Observation: receiving tool output
 
 ### 🔄 Example (ReAct)
-
 ```
 Thought: I need to find the latest weather in Paris.
 Action: Search["weather in Paris"]
@@ -127,22 +72,17 @@ Action: Finish["It's 18°C and cloudy in Paris."]
   </figcaption>
 </figure>
 
----
 
 ## 🔁 Comparison: ReAct vs. CoT
 
-| Feature              | CoT                         | ReAct                              |
-|----------------------|-----------------------------|------------------------------------|
-| Step-by-step logic   | Yes                         | Yes                                |
-| Uses external tools  | No                          | Yes (Actions + Observations)       |
-| Best for             | Logic, math, internal tasks | Multi-step tasks requiring info    |
+| Feature              | Chain-of-Thought (CoT)      | ReAct                               |
+|----------------------|-----------------------------|-------------------------------------|
+| Step-by-step logic   | ✅ Yes                      | ✅ Yes                              |
+| External tools       | ❌ No                       | ✅ Yes (Actions + Observations)     |
+| Best suited for      | Logic, math, internal tasks | Info-seeking, dynamic multi-step tasks |
 
 <Tip>
-Recent models like Deepseek R1 or OpenAI’s o1 were fine-tuned to think before answering. They often use structured tokens like `<think>` and `</think>` to explicitly separate the reasoning phase from the final answer.
+Recent models like **Deepseek R1** or **OpenAI’s o1** were fine-tuned to *think before answering*. They use structured tokens like `<think>` and `</think>` to explicitly separate the reasoning phase from the final answer.
 
 Unlike ReAct or CoT — which are prompting strategies — this is a **training-level technique**, where the model learns to think via examples.
 </Tip>
-
----
-
-Now that we understand internal reasoning and the ReAct method, let’s move on to the second part of the loop: **Act**.

--- a/units/en/unit1/thoughts.mdx
+++ b/units/en/unit1/thoughts.mdx
@@ -1,8 +1,12 @@
 
 # Thought: Internal Reasoning and the ReAct Approach
 
-<Tip> 
-In this section, we dive into the inner workings of an AI agent—its ability to reason and plan. We’ll explore how the agent leverages its internal dialogue to analyze information, break down complex problems into manageable steps, and decide what action to take next. Additionally, we introduce the ReAct approach, a prompting technique that encourages the model to think “step by step” before acting. 
+<Tip>
+
+In this section, we dive into the inner workings of an AI agent—its ability to reason and plan. We’ll explore how the agent leverages its internal dialogue to analyze information, break down complex problems into manageable steps, and decide what action to take next.
+
+Additionally, we introduce the ReAct approach, a prompting technique that encourages the model to think “step by step” before acting.
+
 </Tip>
 
 Thoughts represent the **Agent's internal reasoning and planning processes** to solve the task.
@@ -82,7 +86,9 @@ Action: Finish["It's 18°C and cloudy in Paris."]
 | Best suited for      | Logic, math, internal tasks | Info-seeking, dynamic multi-step tasks |
 
 <Tip>
+
 Recent models like **Deepseek R1** or **OpenAI’s o1** were fine-tuned to *think before answering*. They use structured tokens like `<think>` and `</think>` to explicitly separate the reasoning phase from the final answer.
 
 Unlike ReAct or CoT — which are prompting strategies — this is a **training-level technique**, where the model learns to think via examples.
+
 </Tip>


### PR DESCRIPTION
This PR addresses issue [#525](https://github.com/huggingface/agents-course/issues/525), which noted that the “Thought” section in Unit 1 previously conflated Chain-of-Thought (CoT) with ReAct.

What’s Fixed:
	•	Clearly defined Chain-of-Thought (CoT) as a separate prompting strategy.
	•	Clarified ReAct as an extension of CoT that includes external actions and observations.
	•	Moved the image and explanation of ReAct to the appropriate context.
	•	Added a comparison table showing CoT vs ReAct in terms of behavior and use cases.
	•	Updated explanatory <Tip> on how modern LLMs like DeepSeek R1 and OpenAI’s o1 handle structured internal reasoning.

Outcome:

The revised section now:
	•	Accurately reflects the original academic papers (Kojima et al. for CoT, Yao et al. for ReAct),
	•	Eliminates confusion between the two methods, and
	•	Supports students with a more pedagogically sound and technically correct explanation.