### PR TITLE
Correction_dummy-agent-library.mdx

### DIFF
--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -29,9 +29,9 @@ import os
 from huggingface_hub import InferenceClient
 
 ## You need a token from https://hf.co/settings/tokens, ensure that you select 'read' as the token type. If you run this on Google Colab, you can set it up in the "settings" tab under "secrets". Make sure to call it "HF_TOKEN"
-# HF_TOKEN = os.environ.get("HF_TOKEN")
+HF_TOKEN = os.environ.get("HF_TOKEN")
 
-client = InferenceClient(model="meta-llama/Llama-4-Scout-17B-16E-Instruct")
+client = InferenceClient(model="meta-llama/Llama-4-Scout-17B-16E-Instruct", token=HF_TOKEN)
 ```
 
 We use the `chat` method since is a convenient and reliable way to apply chat templates:


### PR DESCRIPTION
The training material ought to contain the declaration of the HF_Token and the token parameter, in the client initialization.