### PR TITLE
Update URL for GSM8K dataset

### DIFF
--- a/units/en/bonus-unit2/monitoring-and-evaluating-agents-notebook.mdx
+++ b/units/en/bonus-unit2/monitoring-and-evaluating-agents-notebook.mdx
@@ -308,7 +308,7 @@ In offline evaluation, you typically:
 2. Run your agent on that dataset
 3. Compare outputs to the expected results or use an additional scoring mechanism
 
-Below, we demonstrate this approach with the [GSM8K dataset](https://huggingface.co/datasets/gsm8k), which contains math questions and solutions.
+Below, we demonstrate this approach with the [GSM8K dataset](https://huggingface.co/datasets/openai/gsm8k), which contains math questions and solutions.
 
 
 ```python


### PR DESCRIPTION
This PR updates & fixes the URL for GSM8K dataset.

Currently, it's pointing to an outdated link which sends the user to a 404 screen on HF.