### PR TITLE
fix(ko): remove redundant particle in coffee machine example

### DIFF
--- a/units/ko/unit1/what-are-agents.mdx
+++ b/units/ko/unit1/what-are-agents.mdx
@@ -29,7 +29,7 @@
 
 알프레드는 계획을 세운 후, **행동**을 해야 합니다. 알프레드는 세운 계획을 실행하기 위해, 알고 있는 **도구 목록에서 도구**를 사용할 수 있습니다.
 
-이 경우, 커피를 만들기 위해 커피 머신을 사용합니다. 알프레드는는 커피 머신을 작동시켜 커피를 내립니다.
+이 경우, 커피를 만들기 위해 커피 머신을 사용합니다. 알프레드는 커피 머신을 작동시켜 커피를 내립니다.
 <img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit1/make-coffee.jpg" alt="Make coffee"/>
 
 마지막으로, Alfred는 신선하게 내린 커피를 우리에게 가져옵니다.


### PR DESCRIPTION
Removed an extra '는' from the Korean sentence describing Alfred's use of the coffee machine in unit1/what-are-agents.mdx. 
Improves readability and grammatical accuracy.
