### PR TITLE
Update ToolCallingAgent model initialization

### DIFF
--- a/units/en/unit2/smolagents/tool_calling_agents.mdx
+++ b/units/en/unit2/smolagents/tool_calling_agents.mdx
@@ -48,7 +48,7 @@ The key difference is in **how they structure their actions**: instead of execut
 Let's revisit the previous example where Alfred started party preparations, but this time we'll use a `ToolCallingAgent` to highlight the difference. We'll build an agent that can search the web using DuckDuckGo, just like in our Code Agent example. The only difference is the agent type - the framework handles everything else:
 
 ```python
-from smolagents import ToolCallingAgent, DuckDuckGoSearchTool, InferenceClientModel
+from smolagents import ToolCallingAgent, WebSearchTool, InferenceClientModel
 
 agent = ToolCallingAgent(tools=[WebSearchTool()], model=InferenceClientModel())
 


### PR DESCRIPTION
While running the agent with the default model configuration, the following error is raised:

AgentGenerationError: Error while generating output:
(Request ID: Root=1-6916f94a-5dc4b9c97e16bf90732e59b9;9c212a85-b582-424c-8807-a865b3a534cc)

Bad request:
{'code': '400', 'error_type': 'INVALID_TOOL_CHOICE', 'message': 'Supported tool_choice values are "auto" and "none" currently.', 'param': 'tool_choice'}

The issue is caused by the fact that Qwen Coder models do not support tool/function calling.