### PR TITLE
Fix: correct time calculation example in smolagents CodeAgent documentation

### DIFF
--- a/units/en/unit2/smolagents/code_agents.mdx
+++ b/units/en/unit2/smolagents/code_agents.mdx
@@ -180,6 +180,7 @@ agent.run(
     4. Prepare the music and playlist - 45 minutes
 
     If we start right now, at what time will the party be ready?
+    Please calculate the actual clock time, not just the duration.
     """
 )
 ```


### PR DESCRIPTION
This PR updates the prompt in units/en/unit2/smolagents/code_agents.mdx to ensure the agent reliably calculates the actual wall-clock time and not just the duration.

**Issue**

With the previous wording:

> “If we start right now, at what time will the party be ready?”

the agent would sometimes compute only the total duration instead of the final timestamp.
The first screenshot shows this behaviour: the agent returns “3.0 hours” instead of a clock time.

This happens because the model interprets the question ambiguously and chooses the simpler calculation.

<img width="1620" height="1120" alt="Screenshot 2025-11-30 at 15 01 57" src="https://github.com/user-attachments/assets/7adfa0df-bbad-4fb9-93e4-d708eda86176" />

**Fix**

A short clarifying sentence was added:

> “Please calculate the actual clock time, not just the duration.”

This makes the instruction unambiguous.
As shown in the second screenshot, the agent now correctly imports datetime, computes the current time, adds the total minutes, and returns the actual finishing time (e.g., “06:14 PM”).

<img width="1642" height="1280" alt="Screenshot 2025-11-30 at 15 15 01" src="https://github.com/user-attachments/assets/1f238154-ff7a-4d74-b612-96591143e009" />
