### PR TITLE
Fix cyclic dependency in dummy-agent-library

### DIFF
--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -236,16 +236,19 @@ output:
 Let's concatenate the system prompt, the base prompt, the completion until function execution and the result of the function as an Observation and resume generation.
 
 ```python
-messages=[
+messages = [
     {"role": "system", "content": SYSTEM_PROMPT},
-    {"role": "user", "content": "What's the weather in London ?"},
-    {"role": "assistant", "content": output.choices[0].message.content + "Observation:\n" + get_weather('London')},
+    {"role": "user", "content": "What's the weather in London?"},
+    # 1. We "fake" the model's thought and action
+    {"role": "assistant", "content": "Thought: I need to check the weather for London.\nAction:\n```json\n{\"action\": \"get_weather\", \"action_input\": {\"location\": \"London\"}}\n```"},
+    # 2. We provide the observation as a response TO the model
+    {"role": "user", "content": "Observation: " + get_weather('London')}
 ]
 
 output = client.chat.completions.create(
     messages=messages,
-    stream=False,
-    max_tokens=200,
+    max_tokens=200
+    # Don't use the stop sequence here, or it will stop before the Final Answer!
 )
 
 print(output.choices[0].message.content)


### PR DESCRIPTION
-  The current code had a cyclic dependecy - messages were dependent on output and vice-versa
-  This resulted in the folllowing error - 
   ```bash
    print(messages)
           ^^^^^^^^
         NameError: name 'messages' is not defined
 -  Removed that dependency and ensured correct functionality and output
 - Added appropriate comments 