### PR TITLE
Fix: LangGraph deserves a capital L

### DIFF
--- a/units/en/unit2/langgraph/building_blocks.mdx
+++ b/units/en/unit2/langgraph/building_blocks.mdx
@@ -50,7 +50,7 @@ For example, Nodes can contain:
 - **Conditional logic**: Determine next steps
 - **Human intervention**: Get input from users
 
-> 💡 **Info:** Some nodes necessary for the whole workflow like START and END exist from langGraph directly. 
+> 💡 **Info:** Some nodes necessary for the whole workflow like START and END exist from LangGraph directly. 
 
 
 ## 3. Edges

--- a/units/en/unit2/langgraph/introduction.mdx
+++ b/units/en/unit2/langgraph/introduction.mdx
@@ -17,7 +17,7 @@ In this unit, you'll discover:
 ### 5️⃣ [Quiz](./quizz1)
 
 > [!WARNING]
-> The examples in this section require access to a powerful LLM/VLM model. We ran them using the GPT-4o API because it has the best compatibility with langGraph.
+> The examples in this section require access to a powerful LLM/VLM model. We ran them using the GPT-4o API because it has the best compatibility with LangGraph.
 
 By the end of this unit, you'll be equipped to build robust, organized and production ready applications ! 
 

--- a/units/en/unit2/langgraph/quiz1.mdx
+++ b/units/en/unit2/langgraph/quiz1.mdx
@@ -20,7 +20,7 @@ choices={[
   },
   {
     text: "An Agent library for tool calling",
-    explain: "While LangGraph works with agents, the main purpose of langGraph is 'Ochestration'.",
+    explain: "While LangGraph works with agents, the main purpose of LangGraph is 'Orchestration'.",
   }
 ]}
 />


### PR DESCRIPTION
- Fixed 3 instances of "langGraph" → "LangGraph"
- Fixed typo: "Ochestration" → "Orchestration"
