### PR TITLE
Update components.mdx

### DIFF
--- a/units/en/unit2/llama-index/components.mdx
+++ b/units/en/unit2/llama-index/components.mdx
@@ -159,7 +159,9 @@ We also pass in an LLM to the query engine to use for the response.
 ```python
 from llama_index.llms.huggingface_api import HuggingFaceInferenceAPI
 
-llm = HuggingFaceInferenceAPI(model_name="Qwen/Qwen2.5-Coder-32B-Instruct")
+llm = HuggingFaceInferenceAPI(model_name="Qwen/Qwen2.5-Coder-32B-Instruct",
+token=userdata.get('HF_TOKEN'),
+    provider="auto")
 query_engine = index.as_query_engine(
     llm=llm,
     response_mode="tree_summarize",


### PR DESCRIPTION
In the Unit 2 code for HuggingFaceInferenceAPIm the below code gives a 404 inference client not found error

`
llm = HuggingFaceInferenceAPI(model_name="Qwen/Qwen2.5-Coder-32B-Instruct")
`

In order to fix the issue, we need to add the provider and the token

`llm = HuggingFaceInferenceAPI(model_name="Qwen/Qwen2.5-Coder-32B-Instruct",
token=userdata.get('HF_TOKEN'),
    provider="auto")
`