### PR TITLE
Correct the definition of the ReAct prompting technique.

### DIFF
--- a/units/en/unit1/thoughts.mdx
+++ b/units/en/unit1/thoughts.mdx
@@ -4,7 +4,7 @@
 > [!TIP]
 > In this section, we dive into the inner workings of an AI agent—its ability to reason and plan. We’ll explore how the agent leverages its internal dialogue to analyze information, break down complex problems into manageable steps, and decide what action to take next.
 >
-> Additionally, we introduce the ReAct approach, a prompting technique that encourages the model to think “step by step” before acting.
+> Additionally, we introduce the ReAct (Reasoning + Acting) approach, a prompting technique that encourages the model to think before acting. it combines reasoning with actions.
 
 Thoughts represent the **Agent's internal reasoning and planning processes** to solve the task.
 


### PR DESCRIPTION
The document describes both ReAct and Chain-of-Thought (CoT), but their definitions (Line 7 and Line 34) used identical wording, which caused confusion. I updated the ReAct definition to clearly differentiate it from CoT and accurately reflect its reasoning-and-action loop.