### PR TITLE
Remove misleading example for ReAct Prompting

### DIFF
--- a/units/en/unit1/thoughts.mdx
+++ b/units/en/unit1/thoughts.mdx
@@ -66,14 +66,6 @@ Thought: Now that I know the weather...
 Action: Finish["It's 18°C and cloudy in Paris."]
 ```
 
-<figure>
-  <img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit1/ReAct.png" alt="ReAct"/>
-  <figcaption>
-    (d) is an example of the ReAct approach, where we prompt "Let's think step by step", and the model acts between thoughts.
-  </figcaption>
-</figure>
-
-
 ## 🔁 Comparison: ReAct vs. CoT
 
 | Feature              | Chain-of-Thought (CoT)      | ReAct                               |


### PR DESCRIPTION
None of the option in the image is demonstrates ReAct prompting. They are example of other prompting techniques and the image caption is also misleading for user -- stating the option (d) is ReAct prompting example.