### PR TITLE
Update invitees.mdx

### DIFF
--- a/units/en/unit3/agentic-rag/invitees.mdx
+++ b/units/en/unit3/agentic-rag/invitees.mdx
@@ -325,7 +325,7 @@ from llama_index.core.agent.workflow import AgentWorkflow
 from llama_index.llms.huggingface_api import HuggingFaceInferenceAPI
 
 # Initialize the Hugging Face model
-llm = HuggingFaceInferenceAPI(model_name="Qwen/Qwen2.5-Coder-32B-Instruct")
+llm = HuggingFaceInferenceAPI(model_name="Qwen/Qwen3-Coder-30B-A3B-Instruct")
 
 # Create Alfred, our gala agent, with the guest info tool
 alfred = AgentWorkflow.from_tools_or_functions(


### PR DESCRIPTION
Qwen2.5-Coder-32B-Instruct **does not support ToolCalling** while Qwen3-Coder-30B-A3B-Instruct **do support it**. 

When trying to use Qwen2.5-Coder-32B-Instruct during this RAG project the following error kept showing up: Bad request:
`{'code': '422', 'error_type': 'UNSUPPORTED_OPENAI_PARAMS', 'message': 'The following parameters are not supported for this model: tools', 'param': 'tools'}`