### PR TITLE
Use Kimi K2.5 instead of Llama 4

### DIFF
--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -43,6 +43,7 @@ output = client.chat.completions.create(
     ],
     stream=False,
     max_tokens=1024,
+    extra_body={'thinking': {'type': 'disabled'}},
 )
 print(output.choices[0].message.content)
 ```
@@ -164,6 +165,7 @@ output = client.chat.completions.create(
     messages=messages,
     stream=False,
     max_tokens=200,
+    extra_body={'thinking': {'type': 'disabled'}},
 )
 print(output.choices[0].message.content)
 ```
@@ -195,7 +197,8 @@ Do you see the issue?
 output = client.chat.completions.create(
     messages=messages,
     max_tokens=150,
-    stop=["Observation:"] # Let's stop before any actual function is called
+    stop=["Observation:"], # Let's stop before any actual function is called
+    extra_body={'thinking': {'type': 'disabled'}},
 )
 
 print(output.choices[0].message.content)
@@ -246,6 +249,7 @@ output = client.chat.completions.create(
     messages=messages,
     stream=False,
     max_tokens=200,
+    extra_body={'thinking': {'type': 'disabled'}},
 )
 
 print(output.choices[0].message.content)

--- a/units/es/unit1/dummy-agent-library.mdx
+++ b/units/es/unit1/dummy-agent-library.mdx
@@ -75,6 +75,7 @@ output = client.chat.completions.create(
     ],
     stream=False,
     max_tokens=1024,
+    extra_body={'thinking': {'type': 'disabled'}},
 )
 print(output.choices[0].message.content)
 ```

--- a/units/fr/unit1/dummy-agent-library.mdx
+++ b/units/fr/unit1/dummy-agent-library.mdx
@@ -41,6 +41,7 @@ output = client.chat.completions.create(
     ],
     stream=False,
     max_tokens=1024,
+    extra_body={'thinking': {'type': 'disabled'}},
 )
 print(output.choices[0].message.content)
 ```
@@ -162,6 +163,7 @@ output = client.chat.completions.create(
     messages=messages,
     stream=False,
     max_tokens=200,
+    extra_body={'thinking': {'type': 'disabled'}},
 )
 print(output.choices[0].message.content)
 ```
@@ -188,7 +190,8 @@ Voyez-vous le problème ?
 output = client.chat.completions.create(
     messages=messages,
     max_tokens=150,
-    stop=["Observation :"] # Arrêtons avant qu'une fonction ne soit appelée
+    stop=["Observation :"], # Arrêtons avant qu'une fonction ne soit appelée
+    extra_body={'thinking': {'type': 'disabled'}},
 )
 
 print(output.choices[0].message.content)
@@ -239,6 +242,7 @@ output = client.chat.completions.create(
     messages=messages,
     stream=False,
     max_tokens=200,
+    extra_body={'thinking': {'type': 'disabled'}},
 )
 
 print(output.choices[0].message.content)

--- a/units/ko/unit1/dummy-agent-library.mdx
+++ b/units/ko/unit1/dummy-agent-library.mdx
@@ -75,6 +75,7 @@ output = client.chat.completions.create(
     ],
     stream=False,
     max_tokens=1024,
+    extra_body={'thinking': {'type': 'disabled'}},
 )
 print(output.choices[0].message.content)
 ```

--- a/units/ru-RU/unit1/dummy-agent-library.mdx
+++ b/units/ru-RU/unit1/dummy-agent-library.mdx
@@ -75,6 +75,7 @@ output = client.chat.completions.create(
     ],
     stream=False,
     max_tokens=1024,
+    extra_body={'thinking': {'type': 'disabled'}},
 )
 print(output.choices[0].message.content)
 ```

--- a/units/vi/unit1/dummy-agent-library.mdx
+++ b/units/vi/unit1/dummy-agent-library.mdx
@@ -77,6 +77,7 @@ output = client.chat.completions.create(
     ],
     stream=False,
     max_tokens=1024,
+    extra_body={'thinking': {'type': 'disabled'}},
 )
 print(output.choices[0].message.content)
 ```

--- a/units/zh-CN/unit1/dummy-agent-library.mdx
+++ b/units/zh-CN/unit1/dummy-agent-library.mdx
@@ -84,6 +84,7 @@ output = client.chat.completions.create(
     ],
     stream=False,
     max_tokens=1024,
+    extra_body={'thinking': {'type': 'disabled'}},
 )
 print(output.choices[0].message.content)
 ```


### PR DESCRIPTION
Llama 4 is a bit outdated and not supported by any Inference Providers anymore. Let's bump the dummy model to use Kimi K2.5 by default.

Issue reported in https://github.com/huggingface/huggingface_hub/issues/3791


cc @sergiopaniego @burtenshaw (sorry if not pinging the right ones, I just took the top 2 contributors of the repo^^)