### PR TITLE
replace deprecated get_relevant_documents with invoke in BM25 retriever tool

### DIFF
--- a/units/en/unit3/agentic-rag/invitees.mdx
+++ b/units/en/unit3/agentic-rag/invitees.mdx
@@ -195,7 +195,7 @@ class GuestInfoRetrieverTool(Tool):
         self.retriever = BM25Retriever.from_documents(docs)
 
     def forward(self, query: str):
-        results = self.retriever.get_relevant_documents(query)
+        results = self.retriever.invoke(query)
         if results:
             return "\n\n".join([doc.page_content for doc in results[:3]])
         else:


### PR DESCRIPTION
This PR fixes a runtime error caused by the use of the deprecated get_relevant_documents() method in BM25Retriever.

SOLUTION:
Updated GuestInfoRetrieverTool to use invoke() instead of the deprecated get_relevant_documents() method.

This resolves a TypeError caused by LangChain's updated retriever API requiring internal execution context (run_manager). The change ensures compatibility with the current Runnable-based architecture.

<img width="1115" height="132" alt="image" src="https://github.com/user-attachments/assets/48cd5a95-0e89-43f1-9d61-3ee7085ef5f8" />
<img width="1088" height="132" alt="image" src="https://github.com/user-attachments/assets/9980937c-1097-4671-8c44-20a745ed121e" />
