### PR TITLE
fix: lowercase dict key 'futuristic gotham' in SuperheroPartyThemeTool

### DIFF
--- a/units/en/unit2/smolagents/tools.mdx
+++ b/units/en/unit2/smolagents/tools.mdx
@@ -131,7 +131,7 @@ class SuperheroPartyThemeTool(Tool):
         themes = {
             "classic heroes": "Justice League Gala: Guests come dressed as their favorite DC heroes with themed cocktails like 'The Kryptonite Punch'.",
             "villain masquerade": "Gotham Rogues' Ball: A mysterious masquerade where guests dress as classic Batman villains.",
-            "futuristic Gotham": "Neo-Gotham Night: A cyberpunk-style party inspired by Batman Beyond, with neon decorations and futuristic gadgets."
+            "futuristic gotham": "Neo-Gotham Night: A cyberpunk-style party inspired by Batman Beyond, with neon decorations and futuristic gadgets."
         }
 
         return themes.get(category.lower(), "Themed party idea not found. Try 'classic heroes', 'villain masquerade', or 'futuristic Gotham'.")

--- a/units/es/unit2/smolagents/code_agents.mdx
+++ b/units/es/unit2/smolagents/code_agents.mdx
@@ -273,7 +273,7 @@ class SuperheroPartyThemeTool(Tool):
         themes = {
             "classic heroes": "Gala de la Liga de la Justicia: Los invitados vienen vestidos como sus héroes favoritos de DC con cócteles temáticos como 'El Ponche de Kryptonita'.",
             "villain masquerade": "Baile de los Pícaros de Gotham: Una mascarada misteriosa donde los invitados se visten como villanos clásicos de Batman.",
-            "futuristic Gotham": "Noche Neo-Gotham: Una fiesta de estilo cyberpunk inspirada en Batman Beyond, con decoraciones de neón y gadgets futuristas."
+            "futuristic gotham": "Noche Neo-Gotham: Una fiesta de estilo cyberpunk inspirada en Batman Beyond, con decoraciones de neón y gadgets futuristas."
         }
         
         return themes.get(category.lower(), "Idea de fiesta temática no encontrada. Prueba con 'héroes clásicos', 'mascarada de villanos' o 'Gotham futurista'.")

--- a/units/es/unit2/smolagents/tools.mdx
+++ b/units/es/unit2/smolagents/tools.mdx
@@ -130,7 +130,7 @@ class SuperheroPartyThemeTool(Tool):
         themes = {
             "classic heroes": "Gala de la Liga de la Justicia: Los invitados vienen vestidos como sus héroes favoritos de DC con cócteles temáticos como 'El Ponche de Kryptonita'.",
             "villain masquerade": "Baile de los Pícaros de Gotham: Una mascarada misteriosa donde los invitados se visten como villanos clásicos de Batman.",
-            "futuristic Gotham": "Noche Neo-Gotham: Una fiesta de estilo cyberpunk inspirada en Batman Beyond, con decoraciones de neón y gadgets futuristas."
+            "futuristic gotham": "Noche Neo-Gotham: Una fiesta de estilo cyberpunk inspirada en Batman Beyond, con decoraciones de neón y gadgets futuristas."
         }
         
         return themes.get(category.lower(), "Idea de fiesta temática no encontrada. Prueba con 'héroes clásicos', 'mascarada de villanos' o 'Gotham futurista'.")

--- a/units/fr/unit2/smolagents/code_agents.mdx
+++ b/units/fr/unit2/smolagents/code_agents.mdx
@@ -280,7 +280,7 @@ class SuperheroPartyThemeTool(Tool):
         themes = {
             "classic heroes": "Gala de la Justice League : Les invités viennent habillés comme leurs héros DC préférés avec des cocktails thématiques comme 'Le Punch Kryptonite'.",
             "villain masquerade": "Bal des Voyous de Gotham : Une mascarade mystérieuse où les invités s'habillent en méchants classiques de Batman.",
-            "futuristic Gotham": "Nuit Neo-Gotham : Une fête de style cyberpunk inspirée de Batman Beyond, avec des décorations néon et des gadgets futuristes."
+            "futuristic gotham": "Nuit Neo-Gotham : Une fête de style cyberpunk inspirée de Batman Beyond, avec des décorations néon et des gadgets futuristes."
         }
         
         return themes.get(category.lower(), "Idée de fête thématique non trouvée. Essayez 'héros classiques', 'mascarade de méchants', ou 'Gotham futuriste'.")

--- a/units/fr/unit2/smolagents/tools.mdx
+++ b/units/fr/unit2/smolagents/tools.mdx
@@ -131,7 +131,7 @@ class SuperheroPartyThemeTool(Tool):
         themes = {
             "classic heroes": "Justice League Gala : Les invités viennent habillés en leurs héros DC préférés avec des cocktails à thème comme 'The Kryptonite Punch'.",
             "villain masquerade": "Gotham Rogues' Ball : Un bal masqué mystérieux où les invités s'habillent en méchants classiques de Batman.",
-            "futuristic Gotham": "Neo-Gotham Night : Une fête de style cyberpunk inspirée de Batman Beyond, avec des décorations néon et des gadgets futuristes."
+            "futuristic gotham": "Neo-Gotham Night : Une fête de style cyberpunk inspirée de Batman Beyond, avec des décorations néon et des gadgets futuristes."
         }
 
         return themes.get(category.lower(), "Idée de fête à thème non trouvée. Essayez 'classic heroes', 'villain masquerade', ou 'futuristic Gotham'.")

--- a/units/ko/unit2/smolagents/code_agents.mdx
+++ b/units/ko/unit2/smolagents/code_agents.mdx
@@ -279,7 +279,7 @@ class SuperheroPartyThemeTool(Tool):
         themes = {
             "classic heroes": "Justice League Gala: 손님들이 DC 영웅으로 분장하고 '크립토나이트 펀치' 같은 테마 칵테일을 즐깁니다.",
             "villain masquerade": "Gotham Rogues' Ball: 손님들이 배트맨 빌런으로 분장하는 신비로운 가면무도회.",
-            "futuristic Gotham": "Neo-Gotham Night: 배트맨 비욘드에서 영감을 받은 사이버펑크 스타일 파티, 네온 장식과 미래형 소품.",
+            "futuristic gotham": "Neo-Gotham Night: 배트맨 비욘드에서 영감을 받은 사이버펑크 스타일 파티, 네온 장식과 미래형 소품.",
         }
         
         return themes.get(category.lower(), "테마 파티 아이디어를 찾을 수 없습니다. 'classic heroes', 'villain masquerade', 'futuristic Gotham' 중에서 시도해보세요.")

--- a/units/ko/unit2/smolagents/tools.mdx
+++ b/units/ko/unit2/smolagents/tools.mdx
@@ -127,7 +127,7 @@ class SuperheroPartyThemeTool(Tool):
         themes = {
             "classic heroes": "Justice League Gala: 손님들이 DC 영웅으로 분장하고, 'The Kryptonite Punch' 같은 테마 칵테일 제공.",
             "villain masquerade": "Gotham Rogues' Ball: 손님들이 배트맨 빌런으로 분장하는 미스터리 가면무도회.",
-            "futuristic Gotham": "Neo-Gotham Night: 배트맨 비욘드에서 영감을 받은 사이버펑크 스타일 파티, 네온 장식과 미래형 소품.",
+            "futuristic gotham": "Neo-Gotham Night: 배트맨 비욘드에서 영감을 받은 사이버펑크 스타일 파티, 네온 장식과 미래형 소품.",
         }
 
         return themes.get(category.lower(), "테마를 찾을 수 없습니다. 'classic heroes', 'villain masquerade', 'futuristic Gotham' 중에서 선택해보세요.")

--- a/units/zh-CN/unit2/smolagents/code_agents.mdx
+++ b/units/zh-CN/unit2/smolagents/code_agents.mdx
@@ -274,7 +274,7 @@ class SuperheroPartyThemeTool(Tool):
         themes = {
             "classic heroes": "Justice League Gala: Guests come dressed as their favorite DC heroes with themed cocktails like 'The Kryptonite Punch'.",
             "villain masquerade": "Gotham Rogues' Ball: A mysterious masquerade where guests dress as classic Batman villains.",
-            "futuristic Gotham": "Neo-Gotham Night: A cyberpunk-style party inspired by Batman Beyond, with neon decorations and futuristic gadgets."
+            "futuristic gotham": "Neo-Gotham Night: A cyberpunk-style party inspired by Batman Beyond, with neon decorations and futuristic gadgets."
         }
         
         return themes.get(category.lower(), "Themed party idea not found. Try 'classic heroes', 'villain masquerade', or 'futuristic Gotham'.")

--- a/units/zh-CN/unit2/smolagents/tools.mdx
+++ b/units/zh-CN/unit2/smolagents/tools.mdx
@@ -130,7 +130,7 @@ class SuperheroPartyThemeTool(Tool):
         themes = {
             "classic heroes": "Justice League Gala: Guests come dressed as their favorite DC heroes with themed cocktails like 'The Kryptonite Punch'.",
             "villain masquerade": "Gotham Rogues' Ball: A mysterious masquerade where guests dress as classic Batman villains.",
-            "futuristic Gotham": "Neo-Gotham Night: A cyberpunk-style party inspired by Batman Beyond, with neon decorations and futuristic gadgets."
+            "futuristic gotham": "Neo-Gotham Night: A cyberpunk-style party inspired by Batman Beyond, with neon decorations and futuristic gadgets."
         }
         
         return themes.get(category.lower(), "Themed party idea not found. Try 'classic heroes', 'villain masquerade', or 'futuristic Gotham'.")


### PR DESCRIPTION
Fixes #589

## Problem
The `SuperheroPartyThemeTool.forward()` method uses `category.lower()` to look up a theme in the dict, but the dict key was `"futuristic Gotham"` (capital G). Since `.lower()` produces `"futuristic gotham"`, the lookup never matched and always returned the not-found message.

## Solution
Lowercase the dict key from `"futuristic Gotham"` to `"futuristic gotham"` to match the `.lower()` lookup. Applied consistently across all language variants: en, es, fr, ko, zh-CN (both `tools.mdx` and `code_agents.mdx` where applicable).

## Testing
After the fix, calling the tool with `"futuristic Gotham"` (or any capitalization) correctly returns `"Neo-Gotham Night: A cyberpunk-style party..."`.