### PR TITLE
Remove redundant availability checks

### DIFF
--- a/units/en/bonus-unit3/building_your_pokemon_agent.mdx
+++ b/units/en/bonus-unit3/building_your_pokemon_agent.mdx
@@ -164,7 +164,7 @@ class LLMAgentBase(Player):
                 move_name = args.get("move_name")
                 if move_name:
                     chosen_move = self._find_move_by_name(battle, move_name)
-                    if chosen_move and chosen_move in battle.available_moves:
+                    if chosen_move:
                         action_taken = True
                         chat_msg = f"AI Decision: Using move '{chosen_move.id}'."
                         print(chat_msg)
@@ -177,7 +177,7 @@ class LLMAgentBase(Player):
                 pokemon_name = args.get("pokemon_name")
                 if pokemon_name:
                     chosen_switch = self._find_pokemon_by_name(battle, pokemon_name)
-                    if chosen_switch and chosen_switch in battle.available_switches:
+                    if chosen_switch:
                         action_taken = True
                         chat_msg = f"AI Decision: Switching to '{chosen_switch.species}'."
                         print(chat_msg)

--- a/units/es/bonus-unit3/building_your_pokemon_agent.mdx
+++ b/units/es/bonus-unit3/building_your_pokemon_agent.mdx
@@ -164,7 +164,7 @@ class LLMAgentBase(Player):
                 move_name = args.get("move_name")
                 if move_name:
                     chosen_move = self._find_move_by_name(battle, move_name)
-                    if chosen_move and chosen_move in battle.available_moves:
+                    if chosen_move:
                         action_taken = True
                         chat_msg = f"Decisión de la IA: Usando movimiento '{chosen_move.id}'."
                         print(chat_msg)
@@ -177,7 +177,7 @@ class LLMAgentBase(Player):
                 pokemon_name = args.get("pokemon_name")
                 if pokemon_name:
                     chosen_switch = self._find_pokemon_by_name(battle, pokemon_name)
-                    if chosen_switch and chosen_switch in battle.available_switches:
+                    if chosen_switch:
                         action_taken = True
                         chat_msg = f"Decisión de la IA: Cambiando a '{chosen_switch.species}'."
                         print(chat_msg)

--- a/units/fr/bonus-unit3/building_your_pokemon_agent.mdx
+++ b/units/fr/bonus-unit3/building_your_pokemon_agent.mdx
@@ -163,7 +163,7 @@ class LLMAgentBase(Player):
                 move_name = args.get("move_name")
                 if move_name:
                     chosen_move = self._find_move_by_name(battle, move_name)
-                    if chosen_move and chosen_move in battle.available_moves:
+                    if chosen_move:
                         action_taken = True
                         chat_msg = f"AI Decision: Using move '{chosen_move.id}'."
                         print(chat_msg)
@@ -176,7 +176,7 @@ class LLMAgentBase(Player):
                 pokemon_name = args.get("pokemon_name")
                 if pokemon_name:
                     chosen_switch = self._find_pokemon_by_name(battle, pokemon_name)
-                    if chosen_switch and chosen_switch in battle.available_switches:
+                    if chosen_switch:
                         action_taken = True
                         chat_msg = f"AI Decision: Switching to '{chosen_switch.species}'."
                         print(chat_msg)

--- a/units/zh-CN/bonus-unit3/building_your_pokemon_agent.mdx
+++ b/units/zh-CN/bonus-unit3/building_your_pokemon_agent.mdx
@@ -163,7 +163,7 @@ class LLMAgentBase(Player):
                 move_name = args.get("move_name")
                 if move_name:
                     chosen_move = self._find_move_by_name(battle, move_name)
-                    if chosen_move and chosen_move in battle.available_moves:
+                    if chosen_move:
                         action_taken = True
                         chat_msg = f"AI Decision: Using move '{chosen_move.id}'."
                         print(chat_msg)
@@ -176,7 +176,7 @@ class LLMAgentBase(Player):
                 pokemon_name = args.get("pokemon_name")
                 if pokemon_name:
                     chosen_switch = self._find_pokemon_by_name(battle, pokemon_name)
-                    if chosen_switch and chosen_switch in battle.available_switches:
+                    if chosen_switch:
                         action_taken = True
                         chat_msg = f"AI Decision: Switching to '{chosen_switch.species}'."
                         print(chat_msg)


### PR DESCRIPTION
This PR cleans up redundant logical checks in the `LLMAgentBase` action selection

### Changes Made:
* **Removed redundant list lookups:** Removed `and chosen_move in battle.available_moves` and `and chosen_switch in battle.available_switches` inside `choose_move()`. The helper methods `_find_move_by_name` and `_find_pokemon_by_name` already exclusively return objects from these lists, making the secondary checks unnecessary.