### PR TITLE
fix: support Google Colab secrets for HF_TOKEN loading

### DIFF
--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -28,10 +28,15 @@ In the Hugging Face ecosystem, there is a convenient feature called Serverless A
 import os
 from huggingface_hub import InferenceClient
 
-## You need a token from https://hf.co/settings/tokens, ensure that you select 'read' as the token type. If you run this on Google Colab, you can set it up in the "settings" tab under "secrets". Make sure to call it "HF_TOKEN"
-# HF_TOKEN = os.environ.get("HF_TOKEN")
+## You need a token from https://hf.co/settings/tokens, ensure that you select 'read' as the token type.
+## If you run this on Google Colab, add it in the "Secrets" tab (key icon on the left sidebar) and call it "HF_TOKEN".
+try:
+    from google.colab import userdata
+    HF_TOKEN = userdata.get('HF_TOKEN')
+except ImportError:
+    HF_TOKEN = os.environ.get("HF_TOKEN")
 
-client = InferenceClient(model="moonshotai/Kimi-K2.5")
+client = InferenceClient(model="moonshotai/Kimi-K2.5", token=HF_TOKEN)
 ```
 
 We use the `chat` method since it is a convenient and reliable way to apply chat templates:

--- a/units/en/unit1/dummy-agent-library.mdx
+++ b/units/en/unit1/dummy-agent-library.mdx
@@ -32,7 +32,7 @@ from huggingface_hub import InferenceClient
 ## If you run this on Google Colab, add it in the "Secrets" tab (key icon on the left sidebar) and call it "HF_TOKEN".
 try:
     from google.colab import userdata
-    HF_TOKEN = userdata.get('HF_TOKEN')
+    HF_TOKEN = userdata.get("HF_TOKEN")
 except ImportError:
     HF_TOKEN = os.environ.get("HF_TOKEN")
 


### PR DESCRIPTION
Fixes #612

## Problem
The Dummy Agent Library notebook code uses `os.environ.get("HF_TOKEN")` to read the token, which silently returns `None` in Google Colab. In Colab, secrets are stored in a separate keystore and must be accessed via `google.colab.userdata.get()`, not `os.environ`. This causes subsequent API calls to fail — but since the token assignment doesn't raise an error, users have no way to know what went wrong.

## Solution
Updated the token-loading snippet in `dummy-agent-library.mdx` to:
1. Try `google.colab.userdata.get('HF_TOKEN')` first (Colab environment)
2. Fall back to `os.environ.get("HF_TOKEN")` in all other environments (local, Jupyter, etc.)
3. Explicitly pass `token=HF_TOKEN` to `InferenceClient` so the token is actually used

## Testing
Documentation-only change to the code snippet shown in the course page. Logic is straightforward environment detection with a graceful fallback.