### PR TITLE
docs: fix inconsistent FinalAnswerTool import in unit1 tutorial

### DIFF
--- a/units/en/unit1/tutorial.mdx
+++ b/units/en/unit1/tutorial.mdx
@@ -55,11 +55,12 @@ Let's break down the code together:
 - The file begins with some simple but necessary library imports
 
 ```python
-from smolagents import CodeAgent, DuckDuckGoSearchTool, FinalAnswerTool, InferenceClientModel, load_tool, tool
+from smolagents import CodeAgent, DuckDuckGoSearchTool, InferenceClientModel, load_tool, tool
 import datetime
 import requests
 import pytz
 import yaml
+from tools.final_answer import FinalAnswerTool
 ```
 
 As outlined earlier, we will directly use the **CodeAgent** class from **smolagents**.


### PR DESCRIPTION
Fixes #579

## Problem
The partial import snippet at the top of the Unit 1 tutorial page showed `FinalAnswerTool` imported directly from `smolagents`:

```python
from smolagents import CodeAgent, DuckDuckGoSearchTool, FinalAnswerTool, InferenceClientModel, load_tool, tool
```

However, the actual [Space template](https://huggingface.co/spaces/agents-course/First_agent_template/blob/main/app.py) stores `FinalAnswerTool` in a local `tools/` directory and imports it as `from tools.final_answer import FinalAnswerTool`. The complete app.py section later in the same tutorial file already showed this correctly — only the initial partial snippet was inconsistent.

## Solution
Update the partial import snippet to match the complete app.py and the actual Space template structure:
- Remove `FinalAnswerTool` from the `smolagents` import
- Add `from tools.final_answer import FinalAnswerTool` as a separate import line

## Testing
Visual review — both import blocks in tutorial.mdx now match the real Space template structure.