### PR TITLE
docs: update LlamaIndex observability code to use current Arize Phoenix API

### DIFF
--- a/units/en/unit2/llama-index/components.mdx
+++ b/units/en/unit2/llama-index/components.mdx
@@ -214,31 +214,34 @@ Even without direct evaluation, we can **gain insights into how our system is pe
 This is especially useful when we are building more complex workflows and want to understand how each component is performing.
 
 <details>
-<summary>Install LlamaTrace</summary>
+<summary>Install tracing dependencies</summary>
 
-As introduced in the <a href="./llama-hub">section on the LlamaHub</a>, we can install the LlamaTrace callback from Arize Phoenix with the following command:
+As introduced in the <a href="./llama-hub">section on the LlamaHub</a>, we can install the OpenInference instrumentation for LlamaIndex and the Arize Phoenix OTel package with the following command:
 
 ```bash
-pip install -U llama-index-callbacks-arize-phoenix
+pip install -U openinference-instrumentation-llama-index arize-phoenix-otel
 ```
 
-Additionally, we need to set the `PHOENIX_API_KEY` environment variable to our LlamaTrace API key. We can get this by:
-- Creating an account at [LlamaTrace](https://llamatrace.com/login)
+Additionally, we need a `PHOENIX_API_KEY` to send traces to the hosted Phoenix (formerly LlamaTrace) platform. We can get this by:
+- Creating an account at [Arize Phoenix](https://app.phoenix.arize.com)
 - Generating an API key in your account settings
 - Using the API key in the code below to enable tracing
 
 </details>
 
 ```python
-import llama_index
 import os
+from phoenix.otel import register
+from openinference.instrumentation.llama_index import LlamaIndexInstrumentor
 
 PHOENIX_API_KEY = "<PHOENIX_API_KEY>"
-os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"api_key={PHOENIX_API_KEY}"
-llama_index.core.set_global_handler(
-    "arize_phoenix",
-    endpoint="https://llamatrace.com/v1/traces"
+os.environ["PHOENIX_API_KEY"] = PHOENIX_API_KEY
+tracer_provider = register(
+    project_name="llama-index-project",
+    endpoint="https://app.phoenix.arize.com/v1/traces",
 )
+
+LlamaIndexInstrumentor().instrument(tracer_provider=tracer_provider)
 ```
 
 > [!TIP]


### PR DESCRIPTION
Fixes #617

## Problem
The Unit 2.2 (LlamaIndex components) observability section used the old `llamatrace.com` endpoint and the deprecated `llama-index-callbacks-arize-phoenix` callback package. The LlamaTrace service has since migrated to `app.phoenix.arize.com`, and the old authentication method no longer works, causing **401 errors** for all users who try to run the tracing code.

## Solution
Replace the deprecated callback-based approach with the current OpenTelemetry-based instrumentation:

- **Package**: `llama-index-callbacks-arize-phoenix` → `openinference-instrumentation-llama-index arize-phoenix-otel`
- **Endpoint**: `https://llamatrace.com/v1/traces` → `https://app.phoenix.arize.com/v1/traces`  
- **Sign-up URL**: `https://llamatrace.com/login` → `https://app.phoenix.arize.com`
- **API**: `set_global_handler("arize_phoenix", ...)` → `LlamaIndexInstrumentor().instrument(...)` via OpenTelemetry

The new approach uses `phoenix.otel.register` + `LlamaIndexInstrumentor`, which is the officially recommended method in the current Arize Phoenix docs.

## Testing
Code example verified against the [Arize-ai/phoenix tracing tutorial](https://github.com/Arize-ai/phoenix/blob/main/tutorials/tracing/llama_index_tracing_tutorial.ipynb) and current Phoenix documentation.