### PR TITLE
fix(bonus-unit2): update deprecated Langfuse API and add missing ddgs dependency

### DIFF
--- a/units/en/bonus-unit2/monitoring-and-evaluating-agents-notebook.mdx
+++ b/units/en/bonus-unit2/monitoring-and-evaluating-agents-notebook.mdx
@@ -30,7 +30,7 @@ We will need a few libraries that allow us to run, monitor, and evaluate our age
 
 
 ```python
-%pip install langfuse 'smolagents[telemetry]' openinference-instrumentation-smolagents datasets 'smolagents[gradio]' gradio --upgrade
+%pip install langfuse 'smolagents[telemetry]' openinference-instrumentation-smolagents datasets 'smolagents[gradio]' gradio ddgs --upgrade
 ```
 
 ## Step 1: Instrument Your Agent
@@ -164,6 +164,9 @@ You may also pass additional attributes to your spans. These can include `user_i
 
 ```python
 from smolagents import (CodeAgent, DuckDuckGoSearchTool, InferenceClientModel)
+from langfuse import get_client, propagate_attributes
+
+langfuse = get_client()
 
 search_tool = DuckDuckGoSearchTool()
 agent = CodeAgent(
@@ -171,23 +174,19 @@ agent = CodeAgent(
     model=InferenceClientModel()
 )
 
-with langfuse.start_as_current_span(
+with langfuse.start_as_current_observation(
+    as_type="span",
     name="Smolagent-Trace",
-    ) as span:
-    
-    # Run your application here
-    response = agent.run("What is the capital of Germany?")
- 
-    # Pass additional attributes to the span
-    span.update_trace(
-        input="What is the capital of Germany?",
-        output=response,
+) as span:
+    # Propagate additional attributes to all child observations
+    with propagate_attributes(
         user_id="smolagent-user-123",
         session_id="smolagent-session-123456789",
         tags=["city-question", "testing-agents"],
         metadata={"email": "user@langfuse.com"},
-        )
- 
+    ):
+        response = agent.run("What is the capital of Germany?")
+
 # Flush events in short-lived applications
 langfuse.flush()
 ```


### PR DESCRIPTION
## Problem

1. The "Additional Attributes" section uses deprecated Langfuse Python SDK v3 APIs 
   that have been removed in v4:
   - `start_as_current_span()` → replaced by `start_as_current_observation()`
   - `span.update_trace()` → replaced by `propagate_attributes()`

2. `DuckDuckGoSearchTool` requires the `ddgs` package which is not included 
   in the install command. It belongs to smolagents' `toolkit` optional group, 
   not `telemetry`, so `smolagents[telemetry]` does not install it.

## Changes

1. Updated "Additional Attributes" code: `start_as_current_span` → 
   `start_as_current_observation`, `update_trace` → `propagate_attributes`
2. Added `ddgs` to the pip install command in Step 0

## Verification

- Tested in a clean Google Colab environment
- Without `ddgs`: `DuckDuckGoSearchTool()` fails with `ModuleNotFoundError`
- With `ddgs` added: works correctly
- Confirmed new API matches Langfuse SDK v4 documentation

## References

- Langfuse v3→v4 migration: https://langfuse.com/docs/observability/sdk/upgrade-path/python-v3-to-v4
- Langfuse instrumentation docs: https://langfuse.com/docs/observability/sdk/instrumentation
- smolagents pyproject.toml: https://github.com/huggingface/smolagents/blob/main/pyproject.toml