### PR TITLE
Add Brazilian Portuguese translation for Unit 0

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -14,6 +14,6 @@ jobs:
       package_name: agents-course
       path_to_docs: agents-course/units/
       additional_args: --not_python_module
-      languages: en zh-CN ru-RU vi es ko fr
+      languages: en zh-CN ru-RU vi es ko fr pt-BR
     secrets:
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -17,4 +17,4 @@ jobs:
       package_name: agents-course
       path_to_docs: agents-course/units/
       additional_args: --not_python_module
-      languages: en zh-CN ru-RU vi es ko fr
+      languages: en zh-CN ru-RU vi es ko fr pt-BR

--- a/units/pt-BR/_toctree.yml
+++ b/units/pt-BR/_toctree.yml
@@ -1,0 +1,8 @@
+- title: Unidade 0. Boas-vindas ao curso
+  sections:
+    - local: unit0/introduction
+      title: Boas-vindas ao curso
+    - local: unit0/onboarding
+      title: Primeiros passos
+    - local: unit0/discord101
+      title: (Opcional) Discord 101

--- a/units/pt-BR/unit0/discord101.mdx
+++ b/units/pt-BR/unit0/discord101.mdx
@@ -1,0 +1,52 @@
+# (Opcional) Discord 101 [[discord-101]]
+
+<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit0/discord-etiquette.jpg" alt="The Discord Etiquette" width="100%"/>
+
+Este guia foi feito para ajudar você a começar no Discord, uma plataforma de chat gratuita bastante popular nas comunidades de jogos e machine learning.
+
+Entre no servidor da comunidade do Hugging Face no Discord, que **tem mais de 100 mil membros**, clicando <a href="https://discord.gg/UrrTSsSyjb" target="_blank">aqui</a>. É um ótimo lugar para se conectar com outras pessoas!
+
+## O curso de Agents na comunidade do Discord do Hugging Face
+
+Começar a usar o Discord pode ser um pouco confuso no início, então aqui vai um guia rápido para ajudar você a se localizar.
+
+<!-- Not the case anymore, you'll be prompted to choose your interests. Be sure to select **"AI Agents"** to gain access to the AI Agents Category, which includes all the course-related channels. Feel free to explore and join additional channels if you wish! 🚀-->
+
+O servidor da comunidade HF reúne uma comunidade vibrante, com interesses em várias áreas, oferecendo oportunidades de aprendizado por meio de discussões sobre papers, eventos e muito mais.
+
+Depois de [se cadastrar](http://hf.co/join/discord), apresente-se no canal `#introduce-yourself`.
+
+Criamos 4 canais para o Agents Course:
+
+- `agents-course-announcements`: para as **últimas informações do curso**.
+- `🎓-agents-course-general`: para **discussões gerais e conversas informais**.
+- `agents-course-questions`: para **fazer perguntas e ajudar seus colegas**.
+- `agents-course-showcase`: para **mostrar seus melhores agentes**.
+
+Além disso, você também pode conferir:
+
+- `smolagents`: para **discussão e suporte sobre a biblioteca**.
+
+## Dicas para usar o Discord com eficiência
+
+### Como entrar em um servidor
+
+Se você não estiver muito familiarizado com o Discord, talvez queira dar uma olhada neste <a href="https://support.discord.com/hc/en-us/articles/360034842871-How-do-I-join-a-Server#h_01FSJF9GT2QJMS2PRAW36WNBS8" target="_blank">guia</a> sobre como entrar em um servidor.
+
+Aqui está um resumo rápido dos passos:
+
+1. Clique no <a href="https://discord.gg/UrrTSsSyjb" target="_blank">link de convite</a>.
+2. Entre com sua conta do Discord, ou crie uma conta se ainda não tiver uma.
+3. Valide que você não é um agente de IA!
+4. Configure seu apelido e avatar.
+5. Clique em "Join Server".
+
+### Como usar o Discord com eficiência
+
+Aqui estão algumas dicas para usar o Discord da melhor forma:
+
+- Os **canais de voz** estão disponíveis, embora o chat por texto seja mais usado.
+- Você pode formatar texto usando **estilo markdown**, o que é especialmente útil para escrever código. Note que markdown não funciona tão bem para links.
+- Considere abrir threads para **conversas longas**, para manter as discussões organizadas.
+
+Esperamos que este guia seja útil! Se tiver qualquer dúvida, fique à vontade para perguntar no Discord 🤗.

--- a/units/pt-BR/unit0/introduction.mdx
+++ b/units/pt-BR/unit0/introduction.mdx
@@ -1,0 +1,159 @@
+# Bem-vindo(a) ao curso de 🤗 Agentes de IA [[introduction]]
+
+<figure>
+<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit0/thumbnail.jpg" alt="AI Agents Course thumbnail" width="100%"/>
+<figcaption>The background of the image was generated using <a href="https://scenario.com/">Scenario.com</a>
+</figcaption>
+</figure>
+
+
+Bem-vindo(a) ao tema mais empolgante da IA hoje: **Agentes**!
+
+Este curso gratuito vai levar você por uma jornada, **do iniciante ao avançado**, para entender, usar e construir agentes de IA.
+
+Esta primeira unidade vai ajudar você a começar:
+
+- Descobrir o **programa do curso**.
+- **Escolher o caminho** que você vai seguir (modo auditoria ou processo de certificação).
+- **Entender melhor o processo de certificação**.
+- Conhecer a equipe por trás do curso.
+- Criar sua **conta no Hugging Face**.
+- **Entrar no nosso servidor do Discord** e conhecer seus colegas e a equipe.
+
+Vamos começar!
+
+## O que esperar deste curso? [[expect]]
+
+Neste curso, você vai:
+
+- 📖 Estudar agentes de IA em **teoria, design e prática**.
+- 🧑‍💻 Aprender a **usar bibliotecas consolidadas de agentes de IA** como [smolagents](https://huggingface.co/docs/smolagents/en/index), [LlamaIndex](https://www.llamaindex.ai/) e [LangGraph](https://langchain-ai.github.io/langgraph/).
+- 💾 **Compartilhar seus agentes** no Hugging Face Hub e explorar agentes criados pela comunidade.
+- 🏆 Participar de desafios em que você vai **avaliar seus agentes em comparação com os de outros estudantes**.
+- 🎓 **Receber um certificado de conclusão** ao completar as atividades.
+
+E muito mais!
+
+Ao final deste curso, você vai entender **como os agentes funcionam e como criar os seus próprios agentes usando as bibliotecas e ferramentas mais atuais**.
+
+Não se esqueça de **<a href="https://bit.ly/hf-learn-agents">se inscrever no curso!</a>**
+
+(Respeitamos sua privacidade. Coletamos seu endereço de e-mail para **enviar os links quando cada unidade for publicada e compartilhar informações sobre os desafios e atualizações**.)
+
+## Como é o curso? [[course-look-like]]
+
+O curso é composto por:
+
+- *Unidades fundamentais*: onde você aprende os **conceitos de agentes na teoria**.
+- *Hands-on*: onde você aprende **a usar bibliotecas consolidadas de agentes de IA** para treinar seus agentes em ambientes específicos. Essas seções práticas serão em **Hugging Face Spaces**, com um ambiente pré-configurado.
+- *Atividades de casos de uso*: onde você vai aplicar os conceitos aprendidos para resolver um problema real à sua escolha.
+- *O desafio*: onde você colocará seu agente para competir com outros agentes. Também haverá [um leaderboard](https://huggingface.co/spaces/agents-course/Students_leaderboard) para comparar o desempenho dos agentes.
+
+Este **curso é um projeto vivo, que evolui com seu feedback e suas contribuições!** Fique à vontade para [abrir issues e PRs no GitHub](https://github.com/huggingface/agents-course) e participar das discussões no nosso servidor do Discord.
+
+Depois de concluir o curso, você também pode enviar seu feedback [👉 usando este formulário](https://docs.google.com/forms/d/e/1FAIpQLSe9VaONn0eglax0uTwi29rIn4tM7H2sYmmybmG5jJNlE5v0xA/viewform?usp=dialog)
+
+## Qual é o programa? [[syllabus]]
+
+Aqui está o **programa geral do curso**. Uma lista mais detalhada de tópicos será publicada a cada unidade.
+
+| Capítulo | Tema | Descrição |
+| :---- | :---- | :---- |
+| 0 | Introdução | Preparar você com as ferramentas e plataformas que vai usar. |
+| 1 | Fundamentos de Agentes | Explica ferramentas, pensamentos, ações, observações e seus formatos. Explica LLMs, mensagens, tokens especiais e chat templates. Mostra um caso de uso simples usando funções Python como ferramentas. |
+| 2 | Frameworks | Entender como os fundamentos são implementados em bibliotecas populares: smolagents, LangGraph e LlamaIndex |
+| 3 | Casos de uso | Vamos construir alguns casos de uso do mundo real (aberto a PRs 🤗 de pessoas com experiência na criação de agentes) |
+| 4 | Projeto final | Construir um agente para um benchmark selecionado e provar seu entendimento sobre agentes no leaderboard dos estudantes 🚀 |
+
+Além do programa principal, você tem 3 unidades bônus:
+- *Unidade Bônus 1*: Fine-tuning de um LLM para function calling
+- *Unidade Bônus 2*: Observabilidade e avaliação de agentes
+- *Unidade Bônus 3*: Agentes em jogos com Pokemon
+
+Por exemplo, na Unidade Bônus 3, você aprende a construir seu agente para batalhas de Pokemon 🥊.
+
+## Quais são os pré-requisitos?
+
+Para acompanhar este curso, você deve ter:
+
+- Conhecimento básico de Python
+- Conhecimento básico de LLMs (temos uma seção na Unidade 1 para recapitular o que são)
+
+
+## Quais ferramentas eu preciso? [[tools]]
+
+Você só precisa de 2 coisas:
+
+- *Um computador* com conexão à internet.
+- Uma *conta no Hugging Face*: para subir e carregar modelos, agentes e criar Spaces. Se você ainda não tiver uma conta, pode criar uma **[aqui](https://hf.co/join)** (é grátis).
+<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit0/tools.jpg" alt="Course tools needed" width="100%"/>
+
+## O processo de certificação [[certification-process]]
+
+<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit0/three-paths.jpg" alt="Two paths" width="100%"/>
+
+Você pode escolher fazer este curso *em modo auditoria* ou realizar as atividades e *obter um dos dois certificados que emitiremos*.
+
+Se você fizer o curso em modo auditoria, poderá participar de todos os desafios e fazer as atividades se quiser, e **não precisa nos avisar**.
+
+O processo de certificação é **totalmente gratuito**:
+
+- *Para obter uma certificação de fundamentos*: você precisa concluir a Unidade 1 do curso. Isso é voltado para estudantes que querem se atualizar com as tendências mais recentes em agentes.
+- *Para obter um certificado de conclusão*: você precisa concluir a Unidade 1, uma das atividades de caso de uso que propusermos durante o curso e o desafio final.
+
+**Não há prazo** para o processo de certificação.
+
+## Qual é o ritmo recomendado? [[recommended-pace]]
+
+Cada capítulo deste curso foi planejado para **ser concluído em 1 semana, com aproximadamente 3 a 4 horas de estudo por semana**.
+
+Fornecemos um ritmo recomendado:
+
+<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit0/recommended-pace.jpg" alt="Recommended Pace" width="100%"/>
+
+## Como aproveitar melhor o curso? [[advice]]
+
+Para aproveitar ao máximo o curso, temos algumas dicas:
+
+1. <a href="https://discord.gg/UrrTSsSyjb">Participe de grupos de estudo no Discord</a>: estudar em grupo é sempre mais fácil. Para isso, você precisa entrar no nosso servidor do Discord e verificar sua conta do Hugging Face.
+2. **Faça os quizzes e as atividades**: a melhor forma de aprender é com prática e autoavaliação.
+3. **Defina um cronograma para acompanhar o ritmo**: você pode usar nosso cronograma recomendado abaixo ou criar o seu.
+
+<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit0/advice.jpg" alt="Course advice" width="100%"/>
+
+## Quem somos [[who-are-we]]
+
+Este curso é mantido por [Ben Burtenshaw](https://huggingface.co/burtenshaw) e [Sergio Paniego](https://huggingface.co/sergiopaniego). Se você tiver alguma dúvida, fale com a gente no Hub!
+
+## Agradecimentos
+
+Gostaríamos de agradecer às seguintes pessoas por suas contribuições valiosas para este curso:
+
+- **[Joffrey Thomas](https://huggingface.co/Jofthomas)** – Por escrever e desenvolver o curso.
+- **[Thomas Simonini](https://huggingface.co/ThomasSimonini)** – Por escrever e desenvolver o curso.
+- **[Pedro Cuenca](https://huggingface.co/pcuenq)** – Por orientar o curso e fornecer feedback.
+- **[Aymeric Roucher](https://huggingface.co/m-ric)** – Pelas demos incríveis (decoding e agente final), além da ajuda nas partes de smolagents.
+- **[Joshua Lochner](https://huggingface.co/Xenova)** – Pela demo incrível sobre tokenização.
+- **[Quentin Gallouédec](https://huggingface.co/qgallouedec)** – Pela ajuda com o conteúdo do curso.
+- **[David Berenstein](https://huggingface.co/davidberenstein1957)** – Pela ajuda com o conteúdo do curso e a moderação.
+- **[XiaXiao (ShawnSiao)](https://huggingface.co/SSSSSSSiao)** – Tradutora do curso para chinês.
+- **[Jiaming Huang](https://huggingface.co/nordicsushi)** – Tradutor do curso para chinês.
+- **[Kim Noel](https://github.com/knoel99)** - Tradutora do curso para francês.
+- **[Loïck Bourdois](https://huggingface.co/lbourdois)** - Tradutor do curso para francês da [CATIE](https://www.catie.fr/).
+
+
+## Encontrei um bug, ou quero melhorar o curso [[contribute]]
+
+Contribuições são **bem-vindas** 🤗
+
+- Se você *encontrou um bug 🐛 em um notebook*, por favor <a href="https://github.com/huggingface/agents-course/issues">abra uma issue</a> e **descreva o problema**.
+- Se você *quer melhorar o curso*, pode <a href="https://github.com/huggingface/agents-course/pulls">abrir um Pull Request.</a>
+- Se você *quer adicionar uma seção completa ou uma nova unidade*, o ideal é <a href="https://github.com/huggingface/agents-course/issues">abrir uma issue</a> e **descrever que conteúdo quer adicionar antes de começar a escrever, para que possamos orientar você**.
+
+## Ainda tenho dúvidas [[questions]]
+
+Faça sua pergunta no nosso <a href="https://discord.gg/UrrTSsSyjb">servidor do Discord, no canal #agents-course-questions.</a>
+
+Agora que você já tem todas as informações, vamos embarcar ⛵
+
+<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit0/time-to-onboard.jpg" alt="Time to Onboard" width="100%"/>

--- a/units/pt-BR/unit0/onboarding.mdx
+++ b/units/pt-BR/unit0/onboarding.mdx
@@ -1,0 +1,97 @@
+# Onboarding: seus primeiros passos ⛵
+
+<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/unit0/time-to-onboard.jpg" alt="Time to Onboard" width="100%"/>
+
+Agora que você já viu todos os detalhes, vamos começar! Vamos fazer cinco coisas:
+
+1. **Criar sua conta no Hugging Face**, se ainda não tiver feito isso
+2. **Entrar no Discord e se apresentar** (não tenha vergonha 🤗)
+3. **Seguir o Hugging Face Agents Course** no Hub
+4. **Divulgar o curso**
+5. **Rodar modelos localmente com Ollama**, caso você encontre limites de crédito
+
+### Etapa 1: crie sua conta no Hugging Face
+
+(Se você ainda não tiver feito isso) crie uma conta no Hugging Face <a href='https://huggingface.co/join' target='_blank'>aqui</a>.
+
+### Etapa 2: entre na nossa comunidade do Discord
+
+👉🏻 Entre no nosso servidor do Discord <a href="https://discord.gg/UrrTSsSyjb" target="_blank">aqui.</a>
+
+Quando entrar, lembre-se de se apresentar no canal `#introduce-yourself`.
+
+Visite o canal `courses`, dentro de `Hugging Face Hub`, para todas as dúvidas e perguntas relacionadas ao curso.
+
+Se esta for a sua primeira vez usando o Discord, escrevemos um Discord 101 com boas práticas. Veja [a próxima seção](discord101).
+
+### Etapa 3: siga a organização do Hugging Face Agents Course
+
+Fique por dentro dos materiais mais recentes do curso, atualizações e anúncios **seguindo a organização do Hugging Face Agents Course**.
+
+👉 Acesse <a href="https://huggingface.co/agents-course" target="_blank">este link</a> e clique em **follow**.
+
+<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/communication/hf_course_follow.gif" alt="Follow" width="100%"/>
+
+### Etapa 4: divulgue o curso
+
+Ajude a tornar este curso mais visível! Há duas formas de fazer isso:
+
+1. Mostre seu apoio dando uma ⭐ no <a href="https://github.com/huggingface/agents-course" target="_blank">repositório do curso</a>.
+
+<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/communication/please_star.gif" alt="Repo star"/>
+
+2. Compartilhe sua jornada de aprendizado: deixe outras pessoas **sabendo que você está fazendo este curso**! Preparamos uma ilustração que você pode usar nas suas postagens em redes sociais.
+
+<img src="https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/communication/share.png">
+
+Você pode baixar a imagem clicando 👉 [aqui](https://huggingface.co/datasets/agents-course/course-images/resolve/main/en/communication/share.png?download=true)
+
+### Etapa 5: rodando modelos localmente com Ollama (caso você esbarre em limites de crédito)
+
+1. **Instale o Ollama**
+
+    Siga as instruções oficiais <a href="https://ollama.com/download" target="_blank">aqui</a>.
+
+2. **Baixe um modelo localmente**
+
+    ```bash
+    ollama pull qwen2:7b
+    ```
+
+    Aqui, usamos o <a href="https://ollama.com/library/qwen2:7b" target="_blank">modelo qwen2:7b</a>. Veja também <a href="https://ollama.com/search" target="_blank">o site do Ollama</a> para encontrar outros modelos.
+
+3. **Inicie o Ollama em segundo plano (em um terminal)**
+    ```bash
+    ollama serve
+    ```
+
+    Se aparecer o erro `"listen tcp 127.0.0.1:11434: bind: address already in use"`, você pode usar o comando `sudo lsof -i :11434` para identificar o processo
+    ID (PID) que está usando essa porta. Se o processo for `ollama`, provavelmente o script de instalação acima já iniciou o serviço do Ollama,
+    então você pode pular este comando.
+
+4. **Use `LiteLLMModel` em vez de `InferenceClientModel`**
+
+   Para usar o módulo `LiteLLMModel` no `smolagents`, você pode rodar o comando `pip` para instalar o módulo.
+
+```bash
+    pip install 'smolagents[litellm]'
+```
+
+```python
+    from smolagents import LiteLLMModel
+
+    model = LiteLLMModel(
+        model_id="ollama_chat/qwen2:7b",  # Ou teste outros modelos compatíveis com Ollama
+        api_base="http://127.0.0.1:11434",  # Servidor local padrão do Ollama
+        num_ctx=8192,
+    )
+```
+
+5. **Por que isso funciona?**
+- O Ollama serve modelos localmente usando uma API compatível com OpenAI em `http://localhost:11434`.
+- O `LiteLLMModel` foi feito para se comunicar com qualquer modelo que suporte o formato de API de chat/completion da OpenAI.
+- Isso significa que você pode simplesmente trocar `InferenceClientModel` por `LiteLLMModel`, sem precisar alterar o restante do código. É uma solução prática e direta.
+
+Parabéns! 🎉 **Você concluiu o processo de onboarding**! Agora você está pronto(a) para começar a aprender sobre agentes de IA. Divirta-se!
+
+Continue aprendendo e continue incrível 🤗


### PR DESCRIPTION
This PR adds the initial Brazilian Portuguese translation folder for the Agents Course.

It includes:
- `units/pt-BR/_toctree.yml`
- Portuguese translation of Unit 0 pages
- `pt-BR` added to documentation build workflows

Following the maintainer suggestion, this PR starts with Unit 0 so the translation can be reviewed incrementally.

Closes #564
