### PR TITLE
Fix LangChain load_tools import in smolagents tools docs

### DIFF
--- a/units/en/unit2/smolagents/tools.mdx
+++ b/units/en/unit2/smolagents/tools.mdx
@@ -249,28 +249,30 @@ By using `Tool.from_langchain()`, Alfred effortlessly adds advanced search funct
 
 Here's how he does it:
 
-We first need to install the `langchain` integration for `smolagents`.
+We first need to install the LangChain community integration and the SerpAPI package.
 
 ```bash
-pip install -U langchain-community
+pip install -U langchain-community google-search-results
 ```
 
 After installing the langchain integration, make sure to set your SerpAPI key.
 This is required for search-based tools such as `SerpAPITool`:
 
 ```python
+import os
+
 os.environ['SERPAPI_API_KEY'] = '...'
 ```
 
 You can create a SerpAPI key [here](https://serpapi.com/)
 
 ```python
-from langchain.agents import load_tools
+from langchain_community.agent_toolkits.load_tools import load_tools
 from smolagents import CodeAgent, InferenceClientModel, Tool
 
 search_tool = Tool.from_langchain(load_tools(["serpapi"])[0])
 
-agent = CodeAgent(tools=[search_tool], model=model)
+agent = CodeAgent(tools=[search_tool], model=InferenceClientModel())
 
 agent.run("Search for luxury entertainment ideas for a superhero-themed event, such as live performances and interactive experiences.")
 ```

--- a/units/es/unit2/smolagents/tools.mdx
+++ b/units/es/unit2/smolagents/tools.mdx
@@ -248,12 +248,12 @@ Al usar `Tool.from_langchain()`, Alfred añade sin esfuerzo funcionalidades de b
 Así es como lo hace:
 
 ```python
-from langchain.agents import load_tools
+from langchain_community.agent_toolkits.load_tools import load_tools
 from smolagents import CodeAgent, InferenceClientModel, Tool
 
 search_tool = Tool.from_langchain(load_tools(["serpapi"])[0])
 
-agent = CodeAgent(tools=[search_tool], model=model)
+agent = CodeAgent(tools=[search_tool], model=InferenceClientModel())
 
 agent.run("Busca ideas de entretenimiento de lujo para un evento temático de superhéroes, como actuaciones en vivo y experiencias interactivas.")
 ```

--- a/units/fr/unit2/smolagents/tools.mdx
+++ b/units/fr/unit2/smolagents/tools.mdx
@@ -249,12 +249,12 @@ En utilisant `Tool.from_langchain()`, Alfred ajoute sans effort des fonctionnali
 Voici comment il procède :
 
 ```python
-from langchain.agents import load_tools
+from langchain_community.agent_toolkits.load_tools import load_tools
 from smolagents import CodeAgent, InferenceClientModel, Tool
 
 search_tool = Tool.from_langchain(load_tools(["serpapi"])[0])
 
-agent = CodeAgent(tools=[search_tool], model=model)
+agent = CodeAgent(tools=[search_tool], model=InferenceClientModel())
 
 agent.run("Search for luxury entertainment ideas for a superhero-themed event, such as live performances and interactive experiences.")
 ```

--- a/units/ko/unit2/smolagents/tools.mdx
+++ b/units/ko/unit2/smolagents/tools.mdx
@@ -238,12 +238,12 @@ agent.run(
 `Tool.from_langchain()` 메서드로 LangChain 도구를 쉽게 불러올 수 있습니다. Alfred는 Wayne Manor에서 최고의 엔터테인먼트 아이디어를 찾기 위해 LangChain 도구를 활용할 수 있습니다.
 
 ```python
-from langchain.agents import load_tools
+from langchain_community.agent_toolkits.load_tools import load_tools
 from smolagents import CodeAgent, InferenceClientModel, Tool
 
 search_tool = Tool.from_langchain(load_tools(["serpapi"])[0])
 
-agent = CodeAgent(tools=[search_tool], model=model)
+agent = CodeAgent(tools=[search_tool], model=InferenceClientModel())
 
 agent.run("Search for luxury entertainment ideas for a superhero-themed event, such as live performances and interactive experiences.")
 ```

--- a/units/zh-CN/unit2/smolagents/tools.mdx
+++ b/units/zh-CN/unit2/smolagents/tools.mdx
@@ -249,12 +249,12 @@ agent.run(
 具体实现如下：
 
 ```python
-from langchain.agents import load_tools
+from langchain_community.agent_toolkits.load_tools import load_tools
 from smolagents import CodeAgent, InferenceClientModel, Tool
 
 search_tool = Tool.from_langchain(load_tools(["serpapi"])[0])
 
-agent = CodeAgent(tools=[search_tool], model=model)
+agent = CodeAgent(tools=[search_tool], model=InferenceClientModel())
 
 agent.run("Search for luxury entertainment ideas for a superhero-themed event, such as live performances and interactive experiences.")
 ```


### PR DESCRIPTION
## Summary
- update the smolagents tools docs to import `load_tools` from `langchain_community.agent_toolkits.load_tools`
- add the SerpAPI Python package to the English install command
- instantiate `InferenceClientModel()` in the LangChain examples so the snippets are self-contained
- sync the same import/model snippet fix across translated tools docs

## Verification
- `git diff --check`
- `rg -n "from langchain\.agents import load_tools" units || true`
- verified `from langchain_community.agent_toolkits.load_tools import load_tools` and `load_tools(["serpapi"])[0]` in a temporary Python environment