### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/units/zh-CN/unit0/onboarding.mdx
+++ b/units/zh-CN/unit0/onboarding.mdx
@@ -66,7 +66,7 @@ ollama serve
    要在`smolagents`中使用`LiteLLMModel`模块，可运行`pip`命令安装该模块。
 
 ```bash
-pip install smolagents[litellm]
+pip install 'smolagents[litellm]'
 ```
 
 ```bash


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `units/zh-CN/unit0/onboarding.mdx`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`