### PR TITLE
docs(zh-CN): sync invitees retriever API

### DIFF
--- a/units/zh-CN/unit3/agentic-rag/invitees.mdx
+++ b/units/zh-CN/unit3/agentic-rag/invitees.mdx
@@ -185,7 +185,7 @@ class GuestInfoRetrieverTool(Tool):
         self.retriever = BM25Retriever.from_documents(docs)
 
     def forward(self, query: str):
-        results = self.retriever.get_relevant_documents(query)
+        results = self.retriever.invoke(query)
         if results:
             return "\n\n".join([doc.page_content for doc in results[:3]])
         else:


### PR DESCRIPTION
## Summary

Sync the Chinese `invitees.mdx` documentation with upstream commit `a13961b`.

## Changes

- Replace the deprecated `get_relevant_documents()` call with `invoke()`.
- Keep the Chinese prose and MDX structure unchanged.
- Align both BM25 retriever examples with LangChain's current Runnable API.

## Verification

- Confirmed there is no overlapping open PR for this file.
- Ran `git diff --check`.
- Verified code fences and `hfoptions` structure remain unchanged.

Related to #152.