### PR TITLE
docs(zh-CN): sync LangGraph small updates

### DIFF
--- a/units/zh-CN/unit2/langgraph/quiz1.mdx
+++ b/units/zh-CN/unit2/langgraph/quiz1.mdx
@@ -11,7 +11,7 @@
 choices={[
   {
     text: "构建包含 LLM 应用的流程控制的框架",
-    explain: "正确！LangGraph 专门设计用于帮助构建和管理使用 LLM 应用的流程控制。",
+    explain: "LangGraph 专门设计用于帮助构建和管理使用 LLM 应用的流程控制。",
     correct: true
   },
   {
@@ -38,7 +38,7 @@ choices={[
   },
   {
     text: "LangGraph 在保持对执行流程强控制的同时，仍利用 LLM 能力进行决策",
-    explain: "正确！当你需要对 agent 执行流程进行控制时，LangGraph 通过结构化工作流提供可预测的行为。",
+    explain: "当你需要对 agent 执行流程进行控制时，LangGraph 通过结构化工作流提供可预测的行为。",
     correct: true
   },
 ]}
@@ -61,7 +61,7 @@ choices={[
   },
   {
     text: "State 代表在 agent 应用中流转的信息",
-    explain: "正确！State 是 LangGraph 的核心，包含步骤间决策所需的所有信息。你可以定义需要计算的字段，节点可以通过修改这些值来决定流程分支。",
+    explain: "State 是 LangGraph 的核心，包含步骤间决策所需的所有信息。你可以定义需要计算的字段，节点可以通过修改这些值来决定流程分支。",
     correct: true
   },
   {
@@ -78,7 +78,7 @@ choices={[
 choices={[
     {
     text: "根据条件评估决定后续执行节点的边",
-    explain: "正确！条件边允许你的图谱基于当前状态做出动态路由决策，实现工作流中的分支逻辑。",
+    explain: "条件边允许你的图谱基于当前状态做出动态路由决策，实现工作流中的分支逻辑。",
     correct: true
   },
   {
@@ -105,7 +105,7 @@ choices={[
   },
   {
     text: "提供可验证和校验 LLM 输出的结构化工作流",
-    explain: "正确！通过包含验证步骤、校验节点和错误处理路径的结构化工作流，LangGraph 有助于减少幻觉的影响。",
+    explain: "通过包含验证步骤、校验节点和错误处理路径的结构化工作流，LangGraph 有助于减少幻觉的影响。",
     correct: true
   },
   {

--- a/units/zh-CN/unit2/langgraph/when_to_use_langgraph.mdx
+++ b/units/zh-CN/unit2/langgraph/when_to_use_langgraph.mdx
@@ -1,4 +1,4 @@
-# 什么是 `LangGraph`？
+# 什么是 `LangGraph`？ [[what-is-langgraph]]
 
 `LangGraph` 是由 [LangChain](https://www.langchain.com/) 开发的框架，**用于管理集成 LLM 的应用程序的控制流**。
 


### PR DESCRIPTION
## Summary

Sync low-risk LangGraph updates in the Chinese course pages with the English source.

## Change rationale

- English commit `eee3aca` adds the `[[what-is-langgraph]]` anchor and final newline to the LangGraph overview page.
- English commit `b8e5f66` removes `Correct!` prefixes from correct-answer quiz feedback.

## Changes

- Updated `units/zh-CN/unit2/langgraph/when_to_use_langgraph.mdx` with the matching title anchor and final newline.
- Updated `units/zh-CN/unit2/langgraph/quiz1.mdx` by removing five matching `正确！` prefixes from correct-answer explanations.
- Audited `building_blocks.mdx` and `introduction.mdx`; their Chinese pages already reflected the English capitalization corrections, so no change was needed.

## Verification

- Ran `git diff --check`.
- Confirmed the title anchor matches the English source.
- Confirmed the quiz Question component, choices, and `correct: true` counts are unchanged.
- Confirmed no open overlapping PR for this LangGraph batch before submission.

Related to #152.